### PR TITLE
Hicks: Fix per-line date defaults & date field width

### DIFF
--- a/.squad/agents/bishop/charter.md
+++ b/.squad/agents/bishop/charter.md
@@ -1,0 +1,46 @@
+# Bishop — Backend Dev
+
+> Shared data shapes deserve boring, predictable server logic and migrations that explain themselves.
+
+## Identity
+
+- **Name:** Bishop
+- **Role:** Backend Dev
+- **Expertise:** Lamdera backend, shared model evolution, business logic
+- **Style:** methodical, technical, reliability-first
+
+## What I Own
+
+- Backend.elm changes and server-side behavior
+- Shared model and codec-aware backend wiring
+- Migration-safe data flow updates
+
+## How I Work
+
+- Trace data end-to-end before changing types
+- Reuse existing helpers and patterns
+- Surface migration risks early
+
+## Boundaries
+
+**I handle:** backend implementation, shared model changes, migration mechanics.
+
+**I don't handle:** frontend UX decisions, final reviewer approval, or session logging.
+
+**When I'm unsure:** I say so and suggest who might know.
+
+## Model
+
+- **Preferred:** auto
+- **Rationale:** Coordinator selects the best model based on task type — cost first unless writing code
+- **Fallback:** Standard chain — the coordinator handles fallback automatically
+
+## Collaboration
+
+Before starting work, use the provided `TEAM ROOT` for all `.squad/` paths.
+Read `.squad/decisions.md` before working.
+Write team-relevant decisions to `.squad/decisions/inbox/bishop-{brief-slug}.md`.
+
+## Voice
+
+Does not trust "small schema changes." Expects every data shape edit to ripple somewhere important.

--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -1,0 +1,27 @@
+# Project Context
+
+- **Owner:** Théo Zimmermann
+- **Project:** accounting
+- **Stack:** Elm, Lamdera, elm-ui, elm-review, elm-format
+- **Description:** Group expense and accounting app with Lamdera backend and evergreen migrations.
+- **Created:** 2026-04-19
+
+## Learnings
+
+- Initial roster assignment: Backend, model changes, and Lamdera migration ownership.
+- 2026-04-19: Spending/transaction split landed in `src/Types.elm`, `src/Backend.elm`, and `src/Evergreen/Migrate/V26.elm`. Backend storage now separates `spendings : Dict SpendingId Spending` from dated `Day.transactions : List Transaction`, with stable `SpendingId`/`TransactionId` counters on `BackendModel`.
+- Backend edit/delete keeps the old append-only pattern: spendings and transactions are marked `Replaced`/`Deleted`, totals are removed from aggregates, and edits create a fresh spending plus fresh transactions.
+- Current frontend contract preserves the existing dialog by sending a singleton `transactions` list with spending-date defaults and empty `secondaryDescription`; backend normalization still merges by `(date, secondaryDescription)` bucket, summing credits and debits separately by group.
+- Evergreen V26 migrates each legacy day spending into one stored spending plus one transaction with empty secondary description, while frontend/session migration intentionally resets fragile client-side edit/delete state to safe defaults.
+- Codec workflow remains `./check-codecs.sh --regenerate`, and migration validation succeeded with `lamdera check --force` after adding `src/Evergreen/V26/Types.elm` and `src/Evergreen/Migrate/V26.elm`.
+- 2026-04-21: Codec parity fixes can be generation-only; for the current model shape, `./check-codecs.sh --regenerate` refreshed `src/Codecs.elm` without touching `src/Types.elm`, `src/Backend.elm`, or any `src/Evergreen/` files, and validation stayed on `elm-format`, both `lamdera make` targets, and `lamdera live` HTTP 200.
+
+## 2026-04-21: Phase 2 Contract Correction Approved
+
+- **Session timestamp:** 2026-04-21T06:49:24Z
+- **Commit:** `862817b` — Codec parity refresh complete
+- **Role:** Ensured codec alignment in `src/Codecs.elm` after model corrections
+- **Outcome:** All review gates green; part of approved Hudson + Bishop stack
+- **Contract:** Spending owns total invariant; transaction lines own dates/secondary descriptions
+- **Next phase:** Await data model finalization for Evergreen migration
+

--- a/.squad/agents/dallas/charter.md
+++ b/.squad/agents/dallas/charter.md
@@ -1,0 +1,46 @@
+# Dallas — Full-Stack Dev
+
+> If the model still hides the bug, cut closer to the data.
+
+## Identity
+
+- **Name:** Dallas
+- **Role:** Full-Stack Dev
+- **Expertise:** data-model corrections, Elm/Lamdera refactors, backend/frontend contract repair
+- **Style:** focused, structural, minimal
+
+## What I Own
+
+- Correcting cross-layer model mistakes after review feedback
+- Repairing shared types, backend logic, codecs, and minimal UI contracts together
+- Delivering reviewable intermediate states without scope creep
+
+## How I Work
+
+- Start from the user's exact correction, not from the existing abstraction
+- Push data shapes into explicit, retrievable records
+- Keep the UI only as complex as needed to reflect the corrected model
+
+## Boundaries
+
+**I handle:** full-stack model corrections, compile-safe contract changes, review-driven revisions.
+
+**I don't handle:** reviewer approval, migration rollout before review, or extra feature work.
+
+**When I'm unsure:** I say so and suggest who might know.
+
+## Model
+
+- **Preferred:** auto
+- **Rationale:** Coordinator selects the best model based on task type — cost first unless writing code
+- **Fallback:** Standard chain — the coordinator handles fallback automatically
+
+## Collaboration
+
+Before starting work, use the provided `TEAM ROOT` for all `.squad/` paths.
+Read `.squad/decisions.md` before working.
+Write team-relevant decisions to `.squad/decisions/inbox/dallas-{brief-slug}.md`.
+
+## Voice
+
+Skeptical of “almost right” models. If the storage unit is wrong, fixes the storage unit first.

--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -1,0 +1,74 @@
+# Project Context
+
+- **Owner:** Théo Zimmermann
+- **Project:** accounting
+- **Stack:** Elm, Lamdera, elm-ui, elm-review, elm-format
+- **Description:** Full-stack group expense and accounting app with shared models, backend logic, and Elm UI.
+- **Created:** 2026-04-20
+
+## Learnings
+
+- Joined to own the correction that makes each transaction one-sided for exactly one group.
+- User directive: do not generate the Evergreen migration before Théo reviews the model changes.
+- Current reviewable intermediate state keeps `TransactionId` as `{ year, month, day, index }` and defers Evergreen generation until after user review.
+- The one-sided transaction fan-out now happens before persistence: `src/Frontend.elm` emits one record per group/side, while `src/Backend.elm` rebuilds bucket totals and group-members metadata from date/description keys.
+- Key paths for this pass: `src/Types.elm`, `src/Backend.elm`, `src/Frontend.elm`, `src/Codecs.elm`, and `.squad/decisions/inbox/dallas-one-sided-transactions.md`.
+
+- Phase 2 correction: `Spending.total` now owns the invariant, while `Transaction` keeps only one-sided line data and `src/Backend.elm` validates `credits = debits = spending total`.
+- Spending editor pattern: `src/Frontend.elm` keeps a dialog-level default date, but every credit/debit line now owns its own date and optional secondary description fields.
+- Codec impact for this correction stayed in `src/Codecs.elm`; no new `src/Evergreen/` files were generated during the fix-forward pass.
+
+## 2026-04-21: Pre-tweak Checkpoint Commit
+
+**Commit:** ddb8cb7 "Refactor: One-sided transactions with explicit spending records"
+
+**Task:** Create a checkpoint commit for the approved one-sided transaction state before any further model tweaks.
+
+**Committed files:**
+- Core model: `src/Types.elm`, `src/Backend.elm`, `src/Frontend.elm`, `src/Codecs.elm`, `src/Codecs.elm.stub`
+- Squad context: `.squad/agents/`, `.squad/casting/`, `.squad/routing.md`, `.squad/team.md`, `.squad/skills/`
+
+**Excluded files:**
+- `.squad/templates/workflows/*` — these are existing squad infrastructure files, not related to the one-sided transaction work
+- `.squad/decisions/inbox/` — gitignored by design for local-only decision drafts
+
+**Key pattern:** When committing model work, include the squad agent histories and skill files that document the architectural decisions, but exclude unrelated infrastructure additions.
+
+## 2026-04-21: Amount Wrapper and Array Refinement
+
+**Commit:** e64d99e "Refactor: Use Amount wrapper and Array for transactions"
+
+**Task:** Apply two model refinements:
+1. Wrap transaction amounts in `Amount ()` instead of raw `Int`
+2. Change `Day.transactions` from `List` to `Array` for efficiency
+
+**Implementation approach:**
+- Used `Amount ()` (unit phantom type) for transaction amounts since the `side` field already provides credit/debit semantics
+- Updated Backend operations: `Array.get` for indexing, `Array.push` for appends, `Array.map` for transforms, `Array.toList` for iteration
+- Pattern-matched `Amount` constructors throughout to extract/wrap integer values
+- Frontend changes minimal: just wrap amounts when building SpendingTransaction records
+- Codecs auto-regenerated via `./check-codecs.sh --regenerate`
+
+**Key insight:** Transaction-level amounts don't need phantom type tracking (Credit/Debit) because the explicit `side` field carries that information. The `Amount ()` wrapper satisfies the "use Amount" requirement without complicating type signatures across the hierarchy.
+
+**Validation:**
+- Both `lamdera make src/Frontend.elm` and `lamdera make src/Backend.elm` compiled successfully
+- `lamdera live` started and responded with HTTP 200
+- No Evergreen migration files generated (as required)
+
+**Follow-on implications for Phase 2:**
+- The Array storage preserves append-only ordering and stable indexing via `TransactionId.index`
+- SpendingTransaction now explicitly carries `Amount ()`, so Phase 2 multi-bucket UI will handle amounts consistently
+- All aggregate calculations continue to use phantom-typed `Amount Credit`/`Amount Debit` at the bucket/group level
+
+## 2026-04-21: Phase 2 Contract Correction Approved
+
+- **Session timestamp:** 2026-04-21T06:49:24Z
+- **Final verdict:** Current HEAD `862817b` (Hudson + Bishop) approved by Vasquez
+- **Contract confirmed:** Spending owns total invariant; transaction lines own dates/secondary descriptions
+- **Backend validation:** `validateSpendingTransactions` now enforces spending-level invariant
+- **Frontend behavior:** Dialog shows spending date as default seed for new transaction lines
+- **ID-free payload:** `SpendingTransaction` remains free of embedded transaction IDs
+- **Validation gates:** elm-format, codecs, both lamdera makes, HTTP 200 all pass
+- **Next work:** Await data model finalization for Evergreen migration planning
+

--- a/.squad/agents/hicks/charter.md
+++ b/.squad/agents/hicks/charter.md
@@ -1,0 +1,46 @@
+# Hicks — Frontend Dev
+
+> Good UI work starts with stable state transitions and boring, readable views.
+
+## Identity
+
+- **Name:** Hicks
+- **Role:** Frontend Dev
+- **Expertise:** Elm UI, update/view flows, form UX
+- **Style:** practical, concise, implementation-focused
+
+## What I Own
+
+- Frontend Elm pages and components
+- Client-side state transitions and messages
+- UX polish for app flows
+
+## How I Work
+
+- Keep messages and model changes explicit
+- Prefer reuse over ad hoc UI branches
+- Match existing Elm patterns before inventing new ones
+
+## Boundaries
+
+**I handle:** frontend implementation, UI wiring, view/update changes.
+
+**I don't handle:** backend business rules, migration authoring, or final test sign-off.
+
+**When I'm unsure:** I say so and suggest who might know.
+
+## Model
+
+- **Preferred:** auto
+- **Rationale:** Coordinator selects the best model based on task type — cost first unless writing code
+- **Fallback:** Standard chain — the coordinator handles fallback automatically
+
+## Collaboration
+
+Before starting work, use the provided `TEAM ROOT` for all `.squad/` paths.
+Read `.squad/decisions.md` before working.
+Write team-relevant decisions to `.squad/decisions/inbox/hicks-{brief-slug}.md`.
+
+## Voice
+
+Suspicious of accidental UI complexity. Prefers one clear state machine over scattered conditionals.

--- a/.squad/agents/hicks/history.md
+++ b/.squad/agents/hicks/history.md
@@ -47,3 +47,9 @@
 
 - 2026-04-24T17:26:51Z: Diff review: found noisy reorderings (UpdatePassword, UpdateJson, ViewportChanged, ToggleTheme) in src/Frontend.elm. Recommendation: keep Msg case ordering stable; group viewport/config messages together.
 - 20260424T173935Z: Restored canonical Msg ordering in src/Frontend.elm: moved ToggleTheme adjacent to viewport/config messages to reduce noisy diffs.
+
+- 2026-04-26: Short fixes applied to spending editor dialog:
+  - Keep per-line .date as Nothing until the user explicitly changes it; dateText still reflects the dialog default so the UI shows a sensible date.
+  - When the spending date changes, update only line.dateText/datePickerModel for lines that didn't have an explicit date rather than setting line.date — this avoids silently overriding explicit user choices.
+  - Increased detail-date compact column width where needed (confirmed at 200px).
+  (Frontend-only changes in `src/Frontend.elm` by Hicks)

--- a/.squad/agents/hicks/history.md
+++ b/.squad/agents/hicks/history.md
@@ -1,0 +1,49 @@
+# Project Context
+
+- **Owner:** Théo Zimmermann
+- **Project:** accounting
+- **Stack:** Elm, Lamdera, elm-ui, elm-review, elm-format
+- **Description:** Group expense and accounting app with Elm frontend and shared domain types.
+- **Created:** 2026-04-19
+
+## Learnings
+
+- 2026-04-24: Stabilized update-case ordering in src/Frontend.elm: moved UpdatePassword, UpdateJson, ViewportChanged to canonical position matching Types.elm to reduce noisy diffs.
+
+- Initial roster assignment: Frontend Elm implementation and UI flow ownership.
+- 2026-04-19: Spending/transaction split UI now edits spendings as parents and flattens listed transactions as children; `src/Frontend.elm` adds per-line transaction date and secondary description fields while keeping the existing creditor/debitor entry layout.
+- 2026-04-19: The frontend submit path groups line items into `SpendingTransaction` buckets by `(date, secondaryDescription)` and requires each bucket to stay balanced before submit; details come back as grouped transactions and are expanded back into editable lines in `src/Frontend.elm`.
+- 2026-04-19: Shared/backend touchpoints for this split live in `src/Types.elm`, `src/Backend.elm`, `src/Codecs.elm`, and the generated `src/Evergreen/V26/` migration snapshot.
+- 2026-04-21: The spending editor is lighter again in `src/Frontend.elm`: debitors render before creditors, each row shows group/amount first, and date plus secondary description stay collapsed unless the user reveals them or the row already carries custom detail data relative to the spending date.
+- 2026-04-21: `src/Frontend.elm` now keeps the spending editor close to the old inline-row flow by normalizing credit/debit lines to one trailing placeholder row, auto-pruning fully emptied extras, hiding the group label, and using icon-sized detail/remove affordances.
+- 2026-04-21: Follow-up polish in `src/Frontend.elm` restored visible per-row group labels (`Debitor 1`, `Creditor 1`, etc.), removed the extra bold row titles, swapped detail-field order to description-then-date, and replaced text glyph controls with small inline SVG stroke icons while keeping the same auto-growing/collapsing line behavior.
+- 2026-04-21: `agj/elm-simple-icons` was evaluated for the spending editor, but it is a brand-logo library rather than a general UI-control set, so the dialog kept a local inline-SVG icon helper instead of adding the dependency to `elm.json`.
+- 2026-04-22: `src/Frontend.elm` now treats spending-total edits as parent-only changes: debit/credit row amounts keep their current values, while row normalization still preserves the ready trailing placeholder.
+- 2026-04-22: Spending dialog row widths now share one breakpoint-aware contract in `src/Frontend.elm`: desktop keeps a flexible main field plus a 150px compact field, while small screens split paired fields evenly for both primary and revealed detail rows.
+- 2026-04-22: Final frontend bugfix in `src/Frontend.elm` removed remaining cross-column amount autofill during row normalization, so editing one side no longer seeds the untouched opposite side.
+- 2026-04-22: For compact labeled controls in `src/Frontend.elm`, matching block widths are more reliable when the outer `el` owns the width contract and the inner `Input`/`DatePicker.input` simply uses `width fill`.
+
+### 2026-04-21T18:20:11Z: UI Editor Polish Completion
+
+- Completed spending editor refinements in `src/Frontend.elm`:
+  - Auto-growing row behavior with ready first row (normalizeTransactionLines)
+  - No prominent Add button (rows grow via normalization only)
+  - Icon-only affordances: ▸/▾ for details, × for remove
+  - Hidden Group label (Input.labelHidden)
+  - 'Description' as the shorter label copy
+  - Debitors render before creditors (addSpendingInputs order)
+  - Empty extra rows collapse when cleared
+  - Spending-level invariant + line-level detail contract preserved
+- **Validation:** elm-format ✅, lamdera make Frontend/Backend ✅, lamdera live HTTP 200 ✅
+- **Status:** Approved by Vasquez; ready for integration
+
+### 2026-04-22T17:04:59Z: Final UI Seam Fixes Completed
+
+- Final bugfix pass in `src/Frontend.elm` commit `ae26ce6` resolved two UI seams:
+  1. Row normalization (`normalizeSpendingDialogLines`) no longer auto-fills amounts onto untouched opposite side during debitor/creditor edits
+  2. Width layout now shares identical breakpoint-aware contract for both primary and detail rows: outer `el` owns width assignment, inner controls use `width fill`
+- **Validation:** elm-format ✅, codecs ✅, both lamdera makes ✅, HTTP 200 ✅
+- **Team outcome:** PR #39 approved by Vasquez; ready for merge
+
+- 2026-04-24T17:26:51Z: Diff review: found noisy reorderings (UpdatePassword, UpdateJson, ViewportChanged, ToggleTheme) in src/Frontend.elm. Recommendation: keep Msg case ordering stable; group viewport/config messages together.
+- 20260424T173935Z: Restored canonical Msg ordering in src/Frontend.elm: moved ToggleTheme adjacent to viewport/config messages to reduce noisy diffs.

--- a/.squad/agents/hudson/charter.md
+++ b/.squad/agents/hudson/charter.md
@@ -1,0 +1,46 @@
+# Hudson — Full-Stack Dev
+
+> Finish the cleanup pass cleanly, or do not ship it.
+
+## Identity
+
+- **Name:** Hudson
+- **Role:** Full-Stack Dev
+- **Expertise:** generated artifact repair, Elm/Lamdera compile recovery, cross-layer cleanup
+- **Style:** blunt, practical, completion-focused
+
+## What I Own
+
+- Review-clean recovery passes after a model refactor is already on disk
+- Generated artifact alignment across source and codecs
+- Compile-safe cleanup that stays inside a tight scope
+
+## How I Work
+
+- Start from the current worktree, not from wishful reimplementation
+- Make generated and handwritten artifacts agree before expanding scope
+- Stop at the first reviewable intermediate state
+
+## Boundaries
+
+**I handle:** codec cleanup, compile recovery, review-readiness on cross-layer changes.
+
+**I don't handle:** reviewer approval, migration rollout before user review, or speculative UX expansion.
+
+**When I'm unsure:** I say so and suggest who might know.
+
+## Model
+
+- **Preferred:** auto
+- **Rationale:** Coordinator selects the best model based on task type — cost first unless writing code
+- **Fallback:** Standard chain — the coordinator handles fallback automatically
+
+## Collaboration
+
+Before starting work, use the provided `TEAM ROOT` for all `.squad/` paths.
+Read `.squad/decisions.md` before working.
+Write team-relevant decisions to `.squad/decisions/inbox/hudson-{brief-slug}.md`.
+
+## Voice
+
+Impatient with near-miss build states. Prefers fixing the exact broken seam over restarting a good patch from scratch.

--- a/.squad/agents/hudson/history.md
+++ b/.squad/agents/hudson/history.md
@@ -1,0 +1,28 @@
+# Project Context
+
+- **Owner:** Théo Zimmermann
+- **Project:** accounting
+- **Stack:** Elm, Lamdera, elm-ui, elm-review, elm-format
+- **Description:** Full-stack group expense and accounting app with shared models, backend logic, and Elm UI.
+- **Created:** 2026-04-20
+
+## Learnings
+
+- Joined to own the post-model-review cleanup pass after prior authors were locked out on the spending/transaction split artifact.
+- User directive: do not generate the Evergreen migration before Théo reviews the model changes.
+- For the model-only spending/transaction split, the review seam is codec alignment: `src/Codecs.elm` and `src/Codecs.elm.stub` must stay in sync with `src/Types.elm`, and `./check-codecs.sh` is the fastest gate.
+- This cleanup cycle confirmed the current worktree is already in the compile-first review state: no new `src/Evergreen/` migration files were needed, while `elm-format --validate src/`, `./check-codecs.sh`, both `lamdera make` targets, and `lamdera live` with HTTP 200 all passed.
+- `2026-04-20T16:43:52Z`: Model-only spending/transaction split approved for user review
+
+- 2026-04-20: Corrected model pass keeps `TransactionId` as `{ year, month, day, index }`, expands each logical spending bucket into one-sided dated transactions, reconstructs single-bucket spending details for the current dialog, and still defers any Evergreen migration until after user review. Key paths: `src/Types.elm`, `src/Backend.elm`, `src/Codecs.elm`, `src/Codecs.elm.stub`.
+
+- 2026-04-20: Corrected Array target after commit `e64d99e` misread the user request. User asked for Array storage for **spendings**, not for Day.transactions. Changed `BackendModel.spendings` from `Dict SpendingId Spending` to `Array Spending`, and reverted `Day.transactions` from `Array Transaction` back to `List Transaction`. Updated all related code paths and codecs. All validation gates passed with no new Evergreen files. The branch now correctly implements both user directives: Amount wrapper for transaction amounts, and Array storage for spendings.
+
+### 2026-04-21: Phase 2 Contract Correction Approved
+
+- **Session timestamp:** 2026-04-21T06:49:24Z
+- **Approved commits:** Hudson `b7d0444` (spending-level invariant) + Bishop `862817b` (codec parity)
+- **Final verdict:** All review gates pass. Contract confirmed and locked.
+- **Next phase:** Awaiting user approval of any backend record changes before Evergreen migration.
+- **Team coordination:** Ripley clarified contract, Hudson restored invariant, Bishop refreshed codecs, Vasquez approved stack.
+

--- a/.squad/agents/newt/charter.md
+++ b/.squad/agents/newt/charter.md
@@ -1,0 +1,46 @@
+# Newt — Full-Stack Dev
+
+> Untangle the risky seam first, then move only one layer at a time.
+
+## Identity
+
+- **Name:** Newt
+- **Role:** Full-Stack Dev
+- **Expertise:** Elm model refactors, Lamdera contract repair, compile-first recovery work
+- **Style:** calm, cross-layer, incremental
+
+## What I Own
+
+- Cross-layer revisions spanning shared types, backend, codecs, and minimal frontend wiring
+- Compile-first recovery after a stalled or rejected implementation
+- Converting a risky plan into a working intermediate state
+
+## How I Work
+
+- Restore a compiling system before expanding behavior
+- Keep contracts explicit across Types, Backend, Frontend, and Codecs
+- Defer optional scope until the base model is stable and reviewable
+
+## Boundaries
+
+**I handle:** full-stack revisions, compile-first recovery, coordinated contract changes.
+
+**I don't handle:** final reviewer approval, session logging, or speculative scope expansion.
+
+**When I'm unsure:** I say so and suggest who might know.
+
+## Model
+
+- **Preferred:** auto
+- **Rationale:** Coordinator selects the best model based on task type — cost first unless writing code
+- **Fallback:** Standard chain — the coordinator handles fallback automatically
+
+## Collaboration
+
+Before starting work, use the provided `TEAM ROOT` for all `.squad/` paths.
+Read `.squad/decisions.md` before working.
+Write team-relevant decisions to `.squad/decisions/inbox/newt-{brief-slug}.md`.
+
+## Voice
+
+Deliberate about recovery work. Won't accept a \"mostly there\" patch if the compile path or revision boundary is muddy.

--- a/.squad/agents/newt/history.md
+++ b/.squad/agents/newt/history.md
@@ -1,0 +1,27 @@
+# Project Context
+
+- **Owner:** Théo Zimmermann
+- **Project:** accounting
+- **Stack:** Elm, Lamdera, elm-ui, elm-review, elm-format
+- **Description:** Full-stack group expense and accounting app with shared models, backend logic, and Elm UI.
+- **Created:** 2026-04-20
+
+## Learnings
+
+- Joined to own full-stack recovery and compile-first revisions after prior authors were locked out on the spending/transaction split artifact.
+- User directive: do not generate the Evergreen migration before Théo reviews the model changes.
+- Compile-first split shape: `BackendModel` now keeps `spendings : Dict SpendingId Spending` plus dated `Day.transactions`, with `Spending.transactionIds` and `Transaction.spendingId` as the cross-reference seam.
+- Phase 1 edit/delete contract lives in `src/Types.elm`, `src/Backend.elm`, `src/Frontend.elm`, and `src/Codecs.elm`; the frontend still submits one default transaction bucket using the dialog date and an empty secondary description.
+- `RequestSpendingDetails` is the safe bridge for the old dialog: backend returns one editable bucket for singleton spendings and rejects multi-transaction spendings until the later UI pass.
+- `2026-04-20T16:43:52Z`: Model-only spending/transaction split approved for user review
+- `2026-04-21`: The rejected Phase 2 seam in `74261e3` lived in mirrored total checks, not the shared model shape: `src/Backend.elm` still required `credits == debits == total`, and `src/Frontend.elm` still blocked submit unless each side summed to `total`.
+- `2026-04-21`: The recovery fix keeps `Spending.total` as the only amount-level invariant, while line items remain ID-free and still validate per-line date, group, and positive amount; validation stayed on `elm-format src/ --yes`, both `lamdera make` targets, and `lamdera live` returning HTTP 200 with no `src/Evergreen/` diff.
+
+## 2026-04-21: Phase 2 Contract Correction Verdict
+
+- **Session timestamp:** 2026-04-21T06:49:24Z
+- **Status:** Rejected — commit `50629e3` dropped the spending-level invariant entirely
+- **Correction:** Hudson's commit `b7d0444` restored invariant in `validateSpendingTransactions`
+- **Outcome:** Team stack approved; Newt's work rejected but contributed to understanding
+- **Next phase:** Await Théo's data model review and Evergreen migration planning
+

--- a/.squad/agents/ripley/charter.md
+++ b/.squad/agents/ripley/charter.md
@@ -1,0 +1,48 @@
+# Ripley — Lead
+
+> Cross-cutting work needs crisp interfaces, not wishful thinking.
+
+## Identity
+
+- **Name:** Ripley
+- **Role:** Lead
+- **Expertise:** architecture, migration strategy, code review
+- **Style:** direct, skeptical, structured
+
+## What I Own
+
+- Shared technical direction
+- Contract changes across frontend and backend
+- Review and decision-making for risky changes
+
+## How I Work
+
+- Clarify interfaces before implementation fans out
+- Prefer small, explicit changes over clever rewrites
+- Guard migration safety and compatibility
+
+## Boundaries
+
+**I handle:** architecture, review, sequencing, risk management.
+
+**I don't handle:** routine UI implementation, backend plumbing, or test authoring unless explicitly asked.
+
+**When I'm unsure:** I say so and suggest who might know.
+
+**If I review others' work:** On rejection, I may require a different agent to revise or request a new specialist.
+
+## Model
+
+- **Preferred:** auto
+- **Rationale:** Coordinator selects the best model based on task type — cost first unless writing code
+- **Fallback:** Standard chain — the coordinator handles fallback automatically
+
+## Collaboration
+
+Before starting work, use the provided `TEAM ROOT` for all `.squad/` paths.
+Read `.squad/decisions.md` before working.
+Write team-relevant decisions to `.squad/decisions/inbox/ripley-{brief-slug}.md`.
+
+## Voice
+
+Opinionated about boundaries and sequencing. Pushes back on "we'll figure it out later" whenever a migration is involved.

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -1,0 +1,44 @@
+# Project Context
+
+- **Owner:** Théo Zimmermann
+- **Project:** accounting
+- **Stack:** Elm, Lamdera, elm-ui, elm-review, elm-format
+- **Description:** Group expense and accounting app with shared types across frontend and backend.
+- **Created:** 2026-04-19
+
+## Learnings
+
+- Initial roster assignment: Lead for cross-cutting changes, migrations, and review.
+- **Spending model architecture (V24)**: `BackendModel.years` is a `Dict Int Year` → `Dict Int Month` → `Dict Int Day` → `List Spending` hierarchy. Each level carries `totalGroupCredits` for aggregation. Spendings are append-only with soft-delete via `TransactionStatus` (Active/Deleted/Replaced). `TransactionId = { year, month, day, index }` locates a spending by its position in `Day.spendings`.
+- **Duplicate merging**: On spending submit, `Dict.fromListDedupe (+)` in Frontend.elm merges credits/debits with the same group name. This is the only dedup — no date/description grouping exists yet.
+- **Edit flow**: `EditTransaction` marks old spending as `Replaced`, creates a new `Spending` record (possibly at a different date). `DeleteTransaction` marks as `Deleted`. Both adjust `totalGroupCredits` aggregations. The pattern is "mark old + create new" — never mutate in place.
+- **Codecs**: Auto-generated via `./check-codecs.sh --regenerate` using elm-review-derive. `amountCodec` is manually maintained due to phantom type. CI verifies codec freshness.
+- **Evergreen migrations**: Latest is V24. Migrations live in `src/Evergreen/Migrate/`. Backend model was `ModelUnchanged` in V24 migration (only frontend changed for Theme support).
+- **Key files**: `src/Types.elm` (all shared types), `src/Backend.elm` (~780 lines, all backend logic), `src/Frontend.elm` (~1960 lines, full frontend), `src/Codecs.elm` (serialization), `src/Evergreen/V24/Types.elm` (latest snapshot).
+- **User preference**: Théo wants the spending/transaction split phased — model correctness first, UI expansion second. Confirmed spendings are the editable/deletable unit; transactions are the viewable unit in group lists.
+- **Decision written**: `ripley-spending-transaction-split.md` — full plan for the model split including types, migration, backend, frontend, sequencing, and risk assessment.
+- **Stalled revision triage (2026-04-19)**: Hicks' revision of the spending/transaction split was stuck with 12+ compile errors. Root cause: phase mixing (attempted Phase 2 UI changes before Phase 1 compiled) and agent/task mismatch (Hicks is frontend-only, task is full-stack). Codecs were cross-wired between Spending and Transaction types. No Evergreen migration created. Decision: relieve Hicks, discard worktree, launch fresh revision with general-purpose agent. Bishop remains locked out per reviewer protocol. Written to `ripley-stalled-revision-triage.md`.
+- **Elm codec pitfall**: `Codec.object` in elm-codec applies fields positionally to the record constructor. If field order in the codec doesn't match the record definition order, values silently go to wrong fields. Always verify codec field order matches the type alias field order.
+- **Phase discipline matters**: Cross-cutting changes that touch Types + Backend + Frontend + Codecs must compile at every intermediate step. Never layer Phase 2 features before Phase 1 compiles. The cascade of missing definitions becomes unrecoverable faster than expected.
+- **Phase 1 compile-first split (2026-04-19)**: `src/Types.elm` now separates durable `SpendingId` and `TransactionId`, stores spendings in `BackendModel.spendings`, and stores dated `Day.transactions` with bidirectional references (`Spending.transactionIds`, `Transaction.spendingId`).
+- **Phase 1 backend behavior**: `src/Backend.elm` now normalizes submitted transaction buckets by `(year, month, day, secondaryDescription)`, merges credits and debits separately per group inside each bucket, keeps append-only replace/delete semantics, and blocks multi-transaction spending edits until the Phase 2 dialog exists.
+- **Phase 1 frontend contract**: `src/Frontend.elm` still uses the existing spending dialog, but it now edits/deletes by `SpendingId` while listed rows stay transaction-based; submits send a singleton default transaction bucket with the selected date and empty secondary description.
+- **Codecs status**: `src/Codecs.elm` was updated manually for the new backend shape because the derive-based regeneration path did not produce a usable backend codec in this environment; field order still matches the type constructors.
+
+## Learnings (2026-04-20)
+
+- **Phase 2 contract correction (2026-04-20)**: User clarified that bucket-level totals were incorrect. The invariant should be at spending scope (total credits = total debits = stated total). Each transaction line should carry its own date and optional secondary description. Spending date is a UI default for convenience, not a data constraint. Wrote detailed contract to `ripley-phase2-contract-correction.md` covering: remodeled dialog (spendingDate, spendingTotal, transactionLines), backend validation shift to spending scope, deferred Evergreen migration for Transaction.total removal, and open questions for UX refinement. Decision: no code changes until contract approval.
+- **Bucket-total enforcement pattern**: Backend `transactionBucketKey = (year, month, day, secondaryDescription)` groups transactions into buckets for aggregation. `transactionBucketTotals` and `transactionBucketMetadata` compute per-bucket totals and store them in Transaction records. This is a mechanical reusable pattern but conflates UI grouping (buckets as a convenience) with data invariants (totals as a constraint). The user correction separates them: buckets are display/edit grouping only; invariant is spending-scoped.
+- **Migration safety for stored fields**: Removing `Transaction.total` requires Evergreen migration because it is persisted in the backend. Options: (1) Remove entirely + migrate, (2) Repurpose for spending total + migrate, (3) Keep but ignore + fragile. Recommendation: option (1) after user approval. Migration logic: group old transactions by bucket, sum to get spending total, store in new `Spending.total` field.
+- **Frontend dialog modeling**: Current `TransactionBucket` separates date, description, total, and lists of (group, amount, validity) tuples per side. Corrected model flattens to `TransactionLine` (one per visible row) with individual date, description, group, amount, side. Dialog state complexity increases: more form fields, more update messages, more validation hooks. No new types strictly required, but struct design matters for handler clarity.
+
+## 2026-04-21: Phase 2 Contract Correction Approved
+
+- **Session timestamp:** 2026-04-21T06:49:24Z
+- **Contract locked:** User directive captured and implemented by Hudson + Bishop
+- **Spending-level invariant:** Backend now enforces `total credits = total debits = spending.total` after normalization
+- **Per-line ownership:** Dates and optional secondary descriptions stored at transaction level
+- **Spending date role:** UI default seed only, not a data constraint
+- **ID-free wire format:** `SpendingTransaction` remains free of embedded transaction IDs
+- **Next phase:** Data model finalization and Evergreen migration planning await user approval
+

--- a/.squad/agents/scribe/charter.md
+++ b/.squad/agents/scribe/charter.md
@@ -1,20 +1,33 @@
-# Scribe — Scribe
+# Scribe
 
-Documentation specialist maintaining history, decisions, and technical records.
+> The team's memory. Silent, always present, never forgets.
 
-## Project Context
+## Identity
 
-**Project:** accounting
+- **Name:** Scribe
+- **Role:** Session Logger, Memory Manager & Decision Merger
+- **Style:** Silent. Never speaks to the user. Works in the background.
+- **Mode:** Always spawned as `mode: "background"`. Never blocks the conversation.
 
+## What I Own
 
-## Responsibilities
+- `.squad/log/` — session logs
+- `.squad/decisions.md` — the shared decision log
+- `.squad/decisions/inbox/` — the decision drop-box
+- `.squad/orchestration-log/` — per-agent routing evidence
+- Cross-agent context propagation and history maintenance
 
-- Collaborate with team members on assigned work
-- Maintain code quality and project standards
-- Document decisions and progress in history
+## How I Work
 
-## Work Style
+- Resolve all `.squad/` paths from the provided `TEAM ROOT`
+- Merge decisions from the inbox into `decisions.md`
+- Keep logs factual and append-only
+- Commit `.squad/` updates when there is staged squad state
 
-- Read project context and team decisions before starting work
-- Communicate clearly with team members
-- Follow established patterns and conventions
+## Boundaries
+
+**I handle:** Logging, memory, decision merging, cross-agent updates.
+
+**I don't handle:** Domain work, code changes, architectural decisions, or user-facing responses.
+
+**I am invisible.** If a user notices me, something went wrong.

--- a/.squad/agents/scribe/history.md
+++ b/.squad/agents/scribe/history.md
@@ -1,6 +1,9 @@
 # Project Context
 
+- **Owner:** Théo Zimmermann
 - **Project:** accounting
+- **Stack:** Elm, Lamdera, elm-ui, elm-review, elm-format
+- **Description:** Group expense and accounting app with shared frontend/backend model types.
 - **Created:** 2026-04-19
 
 ## Core Context
@@ -9,7 +12,7 @@ Agent Scribe initialized and ready for work.
 
 ## Recent Updates
 
-📌 Team initialized on 2026-04-19
+📌 Team roster established on 2026-04-19 with Ripley, Hicks, Bishop, and Vasquez.
 
 ## Learnings
 

--- a/.squad/agents/vasquez/charter.md
+++ b/.squad/agents/vasquez/charter.md
@@ -1,0 +1,48 @@
+# Vasquez — Tester
+
+> Cross-cutting changes are guilty until they survive ugly edge cases.
+
+## Identity
+
+- **Name:** Vasquez
+- **Role:** Tester
+- **Expertise:** regression analysis, edge-case hunting, validation strategy
+- **Style:** sharp, skeptical, coverage-minded
+
+## What I Own
+
+- Test strategy for risky changes
+- Regression and edge-case coverage
+- Reviewer verdicts on completed work
+
+## How I Work
+
+- Start from failure modes, not happy paths
+- Prefer proving invariants over adding shallow checks
+- Call out hidden coupling early
+
+## Boundaries
+
+**I handle:** test design, verification, reviewer decisions.
+
+**I don't handle:** primary implementation unless explicitly reassigned.
+
+**When I'm unsure:** I say so and suggest who might know.
+
+**If I review others' work:** On rejection, I may require a different agent to revise or request a new specialist.
+
+## Model
+
+- **Preferred:** auto
+- **Rationale:** Coordinator selects the best model based on task type — cost first unless writing code
+- **Fallback:** Standard chain — the coordinator handles fallback automatically
+
+## Collaboration
+
+Before starting work, use the provided `TEAM ROOT` for all `.squad/` paths.
+Read `.squad/decisions.md` before working.
+Write team-relevant decisions to `.squad/decisions/inbox/vasquez-{brief-slug}.md`.
+
+## Voice
+
+Assumes regressions hide at the seams. Will keep pressing until a cross-cutting change has explicit failure coverage.

--- a/.squad/agents/vasquez/history.md
+++ b/.squad/agents/vasquez/history.md
@@ -8,6 +8,8 @@
 
 ## Learnings
 
+- 2026-04-26: Widened the compact per-line field to 200px to ensure full ISO date visibility in transaction details (branch: squad/review/vasquez-fix-date-width).
+
 - Initial roster assignment: Tester and reviewer for risky cross-cutting changes.
 - 2026-04-22: Final UI review for PR #39 / commit `ae26ce6` confirmed the fix belongs in `normalizeSpendingDialogLines` in `src/Frontend.elm`: passive row normalization must not seed opposite-side amounts, while compact row alignment needs width constraints on the outer labeled blocks, not just the inner controls.
 - 2026-04-21: Hicks's spending editor follow-up polish in `src/Frontend.elm` keeps the approved contract intact while restoring labeled group fields (`Debitor 1` / `Creditor 1`), using inline SVG icon controls, and rendering revealed per-line details as Description before Date.

--- a/.squad/agents/vasquez/history.md
+++ b/.squad/agents/vasquez/history.md
@@ -1,0 +1,60 @@
+# Project Context
+
+- **Owner:** Théo Zimmermann
+- **Project:** accounting
+- **Stack:** Elm, Lamdera, elm-ui, elm-review, elm-format
+- **Description:** Group expense and accounting app where shared model changes can break frontend and backend together.
+- **Created:** 2026-04-19
+
+## Learnings
+
+- Initial roster assignment: Tester and reviewer for risky cross-cutting changes.
+- 2026-04-22: Final UI review for PR #39 / commit `ae26ce6` confirmed the fix belongs in `normalizeSpendingDialogLines` in `src/Frontend.elm`: passive row normalization must not seed opposite-side amounts, while compact row alignment needs width constraints on the outer labeled blocks, not just the inner controls.
+- 2026-04-21: Hicks's spending editor follow-up polish in `src/Frontend.elm` keeps the approved contract intact while restoring labeled group fields (`Debitor 1` / `Creditor 1`), using inline SVG icon controls, and rendering revealed per-line details as Description before Date.
+- 2026-04-21: The ready-row/auto-grow/collapse seam is enforced by `normalizeSpendingDialogLines` and `normalizeTransactionLines` in `src/Frontend.elm`, which prune blank extras and keep one trailing placeholder row per debitor/creditor list.
+- 2026-04-22: PR #39 / commit `5eab7a5` keeps the editor contract intact while splitting spending-total edits onto `normalizeSpendingDialogTotal` so total changes stop re-autofilling line amounts, and reuses `transactionLineFlexibleFieldWidth` plus `transactionLineCompactFieldWidth` to keep primary/detail rows on the same width contract across breakpoints in `src/Frontend.elm`.
+
+## Core Context
+
+**Spending/Transaction Model (Phase 2 Contract):**
+- Spending is the edited unit; transactions are immutable line items
+- Spending-level invariant enforced in backend: `total credits = total debits = spending.total`
+- Each transaction line owns its own (year, month, day) and optional secondaryDescription
+- Spending date used only as UI default seed for new lines
+- SpendingTransaction remains ID-free in wire format; backend assigns TransactionId after insertion
+- Codec parity check (`./check-codecs.sh`) required alongside compile health as release gate
+- No Evergreen migration generated; deferred pending user model review
+
+**Spending Dialog Contract (UI Refinement):**
+- Ready first row + one auto-growing trailing placeholder row per debitor/creditor list
+- Empty extra rows collapse when fully cleared
+- Compact icon-only controls: ▸/▾ for details toggle, × for remove
+- Row labels are inline group fields (`Debitor 1`, `Creditor 1`, etc.)
+- Details (Date + Description) hidden by default; auto-reveal when secondary description non-empty OR line date differs from spending date
+- Details render Description before Date when revealed
+- Debitors render before creditors
+- Desktop: one flexible field + one 150px compact field
+- Small screens: paired fields split available width evenly
+- Spending total edits treated as parent-level changes; do not auto-fill debit/credit line amounts
+- Outer `el` wrapper owns width contract; inner Input/DatePicker use `width fill` for alignment reliability
+
+**Validation gates (all passing):**
+- `elm-format --validate src/` ✅
+- `./check-codecs.sh` ✅
+- `lamdera make src/Frontend.elm --output=/dev/null` ✅
+- `lamdera make src/Backend.elm --output=/dev/null` ✅
+- `lamdera live` → HTTP 200 ✅
+
+**Key files:**
+- `src/Types.elm`: SpendingTransaction (ID-free), Spending (with total), Transaction (dated, optional secondary description)
+- `src/Backend.elm`: validateSpendingTransactions (spending-level invariant only)
+- `src/Frontend.elm`: normalizeSpendingDialogLines, normalizeTransactionLinesWithoutAutofill, transactionLineDetailsVisible, addSpendingInputs, width layout contracts
+
+### 2026-04-22T17:04:59Z: Final UI Seam Fixes Approved
+
+- Reviewed Hicks commit `ae26ce6` on `squad-model-change` / PR #39 for final UI seam fixes
+- Confirmed both fixes present:
+  1. Row editing no longer seeds opposite-side amounts via `normalizeTransactionLinesWithoutAutofill`
+  2. Date/field block width now matches amount/field block width via outer `el` width contract
+- Full regression sweep verified: ready first row, trailing placeholder, empty-row collapse, icon controls, debitors-before-creditors, inline labels, hidden details by default, description-before-date, spending-level invariant, line-level ownership all intact
+- **Team outcome:** All regressions passed; PR #39 approved and ready for merge

--- a/.squad/casting/history.json
+++ b/.squad/casting/history.json
@@ -1,0 +1,73 @@
+{
+  "assignments": [
+    {
+      "assignment_id": "2026-04-19-accounting-initial-roster",
+      "created_at": "2026-04-19T16:32:57.375Z",
+      "universe": "Alien",
+      "members": [
+        {
+          "persistent_name": "ripley",
+          "display_name": "Ripley",
+          "role": "Lead"
+        },
+        {
+          "persistent_name": "hicks",
+          "display_name": "Hicks",
+          "role": "Frontend Dev"
+        },
+        {
+          "persistent_name": "bishop",
+          "display_name": "Bishop",
+          "role": "Backend Dev"
+        },
+        {
+          "persistent_name": "vasquez",
+          "display_name": "Vasquez",
+          "role": "Tester"
+        }
+      ]
+    },
+    {
+      "assignment_id": "2026-04-20-accounting-add-newt",
+      "created_at": "2026-04-20T16:34:20.680Z",
+      "universe": "Alien",
+      "members": [
+        {
+          "persistent_name": "ripley",
+          "display_name": "Ripley",
+          "role": "Lead"
+        },
+        {
+          "persistent_name": "hicks",
+          "display_name": "Hicks",
+          "role": "Frontend Dev"
+        },
+        {
+          "persistent_name": "bishop",
+          "display_name": "Bishop",
+          "role": "Backend Dev"
+        },
+        {
+          "persistent_name": "newt",
+          "display_name": "Newt",
+          "role": "Full-Stack Dev"
+        },
+        {
+          "persistent_name": "hudson",
+          "display_name": "Hudson",
+          "role": "Full-Stack Dev"
+        },
+        {
+          "persistent_name": "dallas",
+          "display_name": "Dallas",
+          "role": "Full-Stack Dev"
+        },
+        {
+          "persistent_name": "vasquez",
+          "display_name": "Vasquez",
+          "role": "Tester"
+        }
+      ]
+    }
+  ]
+}

--- a/.squad/casting/policy.json
+++ b/.squad/casting/policy.json
@@ -1,0 +1,35 @@
+{
+  "casting_policy_version": "1.1",
+  "allowlist_universes": [
+    "The Usual Suspects",
+    "Reservoir Dogs",
+    "Alien",
+    "Ocean's Eleven",
+    "Arrested Development",
+    "Star Wars",
+    "The Matrix",
+    "Firefly",
+    "The Goonies",
+    "The Simpsons",
+    "Breaking Bad",
+    "Lost",
+    "Marvel Cinematic Universe",
+    "DC Universe"
+  ],
+  "universe_capacity": {
+    "The Usual Suspects": 6,
+    "Reservoir Dogs": 8,
+    "Alien": 8,
+    "Ocean's Eleven": 14,
+    "Arrested Development": 15,
+    "Star Wars": 12,
+    "The Matrix": 10,
+    "Firefly": 10,
+    "The Goonies": 8,
+    "The Simpsons": 20,
+    "Breaking Bad": 12,
+    "Lost": 18,
+    "Marvel Cinematic Universe": 25,
+    "DC Universe": 18
+  }
+}

--- a/.squad/casting/registry.json
+++ b/.squad/casting/registry.json
@@ -1,0 +1,86 @@
+{
+  "assignment_universe": "Alien",
+  "members": [
+    {
+      "persistent_name": "ripley",
+      "display_name": "Ripley",
+      "role": "Lead",
+      "universe": "Alien",
+      "created_at": "2026-04-19T16:32:57.375Z",
+      "legacy_named": false,
+      "status": "active"
+    },
+    {
+      "persistent_name": "hicks",
+      "display_name": "Hicks",
+      "role": "Frontend Dev",
+      "universe": "Alien",
+      "created_at": "2026-04-19T16:32:57.375Z",
+      "legacy_named": false,
+      "status": "active"
+    },
+    {
+      "persistent_name": "bishop",
+      "display_name": "Bishop",
+      "role": "Backend Dev",
+      "universe": "Alien",
+      "created_at": "2026-04-19T16:32:57.375Z",
+      "legacy_named": false,
+      "status": "active"
+    },
+    {
+      "persistent_name": "newt",
+      "display_name": "Newt",
+      "role": "Full-Stack Dev",
+      "universe": "Alien",
+      "created_at": "2026-04-20T16:34:20.680Z",
+      "legacy_named": false,
+      "status": "active"
+    },
+    {
+      "persistent_name": "hudson",
+      "display_name": "Hudson",
+      "role": "Full-Stack Dev",
+      "universe": "Alien",
+      "created_at": "2026-04-20T16:34:20.680Z",
+      "legacy_named": false,
+      "status": "active"
+    },
+    {
+      "persistent_name": "dallas",
+      "display_name": "Dallas",
+      "role": "Full-Stack Dev",
+      "universe": "Alien",
+      "created_at": "2026-04-20T17:23:14.479Z",
+      "legacy_named": false,
+      "status": "active"
+    },
+    {
+      "persistent_name": "vasquez",
+      "display_name": "Vasquez",
+      "role": "Tester",
+      "universe": "Alien",
+      "created_at": "2026-04-19T16:32:57.375Z",
+      "legacy_named": false,
+      "status": "active"
+    },
+    {
+      "persistent_name": "scribe",
+      "display_name": "Scribe",
+      "role": "Session Logger",
+      "universe": "exempt",
+      "created_at": "2026-04-19T16:32:57.375Z",
+      "legacy_named": false,
+      "status": "active"
+    },
+    {
+      "persistent_name": "ralph",
+      "display_name": "Ralph",
+      "role": "Work Monitor",
+      "universe": "exempt",
+      "created_at": "2026-04-19T16:32:57.375Z",
+      "legacy_named": false,
+      "status": "active"
+    }
+  ]
+}

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2,10 +2,144 @@
 
 ## Active Decisions
 
-No decisions recorded yet.
+### Model-Only Spending/Transaction Split (2026-04-20)
+
+**Status:** Approved for user review.
+
+**Decision:** Keep the spending/transaction split in a compile-first intermediate state: spendings are stored separately from dated transactions, backend edit/delete works at the spending level, and the current dialog remains a singleton transaction adapter.
+
+**Validation:**
+- Model split in `src/Types.elm`: `spendings` separated from dated `transactions` with explicit `SpendingId`/`TransactionId` references
+- Frontend/backend seams aligned: `CreateSpending`, `EditSpending`, `DeleteSpending`, `RequestSpendingDetails`, `SpendingDetails`, `SpendingError`
+- Codec parity clean: `./check-codecs.sh` passed
+- Compile targets pass: `lamdera make src/Frontend.elm` ✅, `lamdera make src/Backend.elm` ✅
+- Development server responds: `lamdera live` → HTTP 200 ✅
+- No Evergreen migration generated
+
+**Constraint:** Do not generate Evergreen migration files until Théo reviews and accepts the model changes.
+
+**Next Phase:** Phase 2 can expand the dialog to edit multiple transaction buckets once the model is approved.
+
+### Phase 2 Contract Correction (2026-04-21)
+
+**Status:** Approved and implemented.
+
+**Decision:** Phase 2 spending/transaction split is now complete and validated:
+- **Spending owns total invariant:** `total credits = total debits = spending.total` enforced at spending scope (not bucket scope).
+- **Transaction lines own dates:** Each credit/debit line has its own (year, month, day).
+- **Transaction lines own secondary descriptions:** Each credit/debit line can have optional secondaryDescription.
+- **Spending date is UI default seed:** When adding new lines, pre-fill dates with spending date.
+- **SpendingTransaction remains ID-free:** Wire format unchanged; backend assigns TransactionId after insertion.
+
+**Implementation stack (approved):**
+- Hudson commit `b7d0444`: Restored spending-level invariant in `src/Backend.elm`.
+- Bishop commit `862817b`: Refreshed codec parity in `src/Codecs.elm`.
+
+**Validation:**
+- Compiler: `lamdera make src/Frontend.elm` ✅, `lamdera make src/Backend.elm` ✅
+- Formatting: `elm-format --validate src/` ✅
+- Codecs: `./check-codecs.sh` ✅
+- Development server: `lamdera live` → HTTP 200 ✅
+- No Evergreen migration generated (deferred pending data model finalization)
+
+**Constraint:** Do not generate Evergreen migration files until Théo reviews and accepts any backend `Spending` and `Transaction` record changes.
+
+**Next Phase:** Phase 2 dialog expansion can proceed to multi-bucket editing once this contract is committed.
+
+### UI Lightweight Refinement (2026-04-21)
+
+**Status:** Approved and implemented.
+
+**Decision:** Refine the approved spending editor frontend to be lighter while preserving the contract:
+- Collapse per-line date and secondary-description fields by default.
+- Auto-show (expand) those fields whenever the secondary description is non-empty OR the line date differs from the spending date.
+- Restore debitors-before-creditors rendering order (debits first, then credits).
+- No backend or wire-format changes; `SpendingTransaction` remains ID-free and contract-correct.
+
+**Implementation stack (approved):**
+- Hicks commit `6d0a983`: Refined `src/Frontend.elm` spending editor UI.
+
+**Validation:**
+- Compiler: `lamdera make src/Frontend.elm` ✅, `lamdera make src/Backend.elm` ✅
+- Formatting: `elm-format --validate src/` ✅
+- Codecs: `./check-codecs.sh` ✅
+- Development server: `lamdera live` → HTTP 200 ✅
+
+**Constraint:** Frontend-only refinement. No changes to `SpendingTransaction` shape, `CreateSpending`/`EditSpending` payloads, or backend behavior. Reveal/collapse state is session-local and does not persist.
+
+**Next Phase:** Dialog can be further expanded to multi-bucket editing once main-branch integration is complete.
+
+### UI Icon Polish (2026-04-21)
+
+**Status:** Approved and implemented.
+
+**Decision:** Refine the spending editor frontend with focused UI polish:
+- Remove bold row styling; move row identity to inline group-field labels (`Debitor 1`, `Creditor 1`, etc.)
+- Reorder revealed detail fields to show `Description` before `Date`
+- Replace rough disclosure/remove glyphs with clean inline SVG controls (`strokedIcon`, `detailsCollapsedIcon`, `detailsExpandedIcon`, `removeIcon`)
+- Reject `agj/elm-simple-icons` as unsuitable: package provides brand/project logos, not generic disclose/remove semantics
+
+**Implementation stack (approved):**
+- Hicks commit: Polished `src/Frontend.elm` spending editor
+
+**Validation:**
+- Compiler: `lamdera make src/Frontend.elm` ✅, `lamdera make src/Backend.elm` ✅
+- Formatting: `elm-format --validate src/` ✅
+- Development server: `lamdera live` → HTTP 200 ✅
+
+**Constraint:** Frontend-only refinement. No changes to `SpendingTransaction` shape, payloads, backend behavior, or approved contract. Debitors continue to render before creditors. Ready first row, one trailing placeholder, and empty-row pruning preserved.
+
+**Reviewer:** Vasquez approved. Verified all requirements met and contract upheld.
+
+### UI Row Width Fixes (2026-04-22)
+
+**Status:** Approved and implemented.
+
+**Decision:** Fix spending dialog row width contract consistency:
+- Treat spending total edits as parent-level changes only; do not auto-fill debit/credit line amounts
+- Use identical breakpoint-aware width split for both compact first row and revealed detail row
+  - Desktop: one flexible text field + one compact 150px field
+  - Small screens: paired fields split available width evenly
+
+**Implementation stack (approved):**
+- Hicks commit `5eab7a5`: Fixed row width consistency in `src/Frontend.elm`
+
+**Validation:**
+- Compiler: `lamdera make src/Frontend.elm` ✅, `lamdera make src/Backend.elm` ✅
+- Formatting: `elm-format --validate src/` ✅
+- Codecs: `./check-codecs.sh` ✅
+- Development server: `lamdera live` → HTTP 200 ✅
+
+**Constraint:** Frontend-only refinement. No changes to `SpendingTransaction` shape, payloads, or backend behavior. Preserves all approved editor contract behaviors (ready first row, trailing placeholder, debitors before creditors, inline group labels, hidden details by default).
+
+**Reviewer:** Vasquez approved. Verified all requirements met and no regressions against approved contract. PR #39 ready for merge.
 
 ## Governance
 
 - All meaningful changes require team consensus
 - Document architectural decisions here
 - Keep history focused on work, decisions focused on direction
+
+
+### UI Final Fixes (2026-04-22)
+
+**Status:** Approved and implemented.
+
+**Decision:** Fix spending-editor UI seams in committed frontend:
+- Disable auto-fill: editing one debitor/creditor row no longer seeds the untouched opposite side (debit ↔ credit balance preserved by read-only peer)
+- Match layout widths: `Date + field` block wrapper width equals `Amount + field` block wrapper width, inner controls fill equally
+
+**Implementation stack (approved):**
+- Hicks commit `ae26ce6`: Fixed row normalization and layout width in `src/Frontend.elm`
+
+**Validation:**
+- Formatter: `elm-format --validate src/` ✅
+- Codecs: `./check-codecs.sh` ✅
+- Compiler: `lamdera make src/Frontend.elm` ✅, `lamdera make src/Backend.elm` ✅
+- Development server: `lamdera live` → HTTP 200 ✅
+
+**Constraint:** Frontend-only refinement. No changes to `SpendingTransaction` shape, payloads, or backend behavior. All previously approved editor contracts preserved (ready first row, trailing placeholder, debitors before creditors, inline labels, hidden details by default, description before date, spending-level invariant).
+
+**Reviewer:** Vasquez approved. Verified both fixes present and no regressions. PR #39 ready for merge.
+
+**Next Phase:** Main-branch integration complete. Phase 2 multi-bucket editing expansion can proceed.

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,9 +1,10 @@
 ---
-updated_at: 2026-04-19T14:28:26.543Z
-focus_area: Initial setup
-active_issues: []
+updated_at: 2026-04-21T17:31:32Z
+focus_area: Refining approved spending editor UI
+active_issues:
+  - Lighten the spending editor UI while preserving the approved spending/transaction contract
 ---
 
 # What We're Focused On
 
-Getting started. Updated by coordinator at session start.
+Phase 2 contract correction is approved. Current work is a frontend refinement pass: lighter layout, hidden line-level date/secondary description by default, and debitors first again, without changing the approved data contract or generating Evergreen migrations.

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -6,12 +6,15 @@ How to decide who handles what.
 
 | Work Type | Route To | Examples |
 |-----------|----------|----------|
-| {domain 1} | {Name} | {example tasks} |
-| {domain 2} | {Name} | {example tasks} |
-| {domain 3} | {Name} | {example tasks} |
-| Code review | {Name} | Review PRs, check quality, suggest improvements |
-| Testing | {Name} | Write tests, find edge cases, verify fixes |
-| Scope & priorities | {Name} | What to build next, trade-offs, decisions |
+| Architecture, migrations, cross-cutting design | Ripley | Model changes, migration strategy, contract changes |
+| Frontend Elm UI and flows | Hicks | Forms, views, update logic, Elm UI polish |
+| Backend and Lamdera server logic | Bishop | Backend.elm changes, shared model wiring, business rules |
+| Full-stack recovery and cross-layer revisions | Newt | Compile-first model changes, contract repair, coordinated revisions |
+| Full-stack recovery and generated-artifact cleanup | Hudson | Codec regeneration, compile-safe repair, review-ready intermediate states |
+| Full-stack model corrections | Dallas | Data-model corrections, one-sided transaction normalization, compile-safe contract repairs |
+| Code review | Ripley | Review PRs, check quality, suggest improvements |
+| Testing | Vasquez | Write tests, find edge cases, verify fixes |
+| Scope & priorities | Ripley | What to build next, trade-offs, decisions |
 | Async issue work (bugs, tests, small features) | @copilot 🤖 | Well-defined tasks matching capability profile |
 | Session logging | Scribe | Automatic — never needs routing |
 
@@ -19,8 +22,14 @@ How to decide who handles what.
 
 | Label | Action | Who |
 |-------|--------|-----|
-| `squad` | Triage: analyze issue, evaluate @copilot fit, assign `squad:{member}` label | Lead |
-| `squad:{name}` | Pick up issue and complete the work | Named member |
+| `squad` | Triage: analyze issue, evaluate @copilot fit, assign `squad:{member}` label | Ripley |
+| `squad:ripley` | Pick up issue and complete the work | Ripley |
+| `squad:hicks` | Pick up issue and complete the work | Hicks |
+| `squad:bishop` | Pick up issue and complete the work | Bishop |
+| `squad:newt` | Pick up issue and complete the work | Newt |
+| `squad:hudson` | Pick up issue and complete the work | Hudson |
+| `squad:dallas` | Pick up issue and complete the work | Dallas |
+| `squad:vasquez` | Pick up issue and complete the work | Vasquez |
 | `squad:copilot` | Assign to @copilot for autonomous work (if enabled) | @copilot 🤖 |
 
 ### How Issue Assignment Works

--- a/.squad/skills/dialog-default-line-fields/SKILL.md
+++ b/.squad/skills/dialog-default-line-fields/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: "dialog-default-line-fields"
+description: "Keep convenience defaults at dialog level while persisting ownership on individual lines"
+domain: "ui-contracts"
+confidence: "medium"
+source: "earned"
+---
+
+## Context
+
+Use this when a parent form needs a convenience field (like a shared date) but the persisted data really belongs on child rows. It helps keep the storage model honest without making data entry painful.
+
+## Patterns
+
+- Store the invariant or aggregate on the true root record, not on UI grouping containers.
+- Let each child row own its persisted fields, even if the dialog also exposes a parent-level default.
+- When the default changes, only rewrite child rows that are still using that default or are blank; leave explicitly customized rows alone.
+- Keep lightweight/collapsed-vs-expanded presentation state out of persisted child payloads; compute it from row content or store it only in dialog-local state.
+- Auto-reveal detail controls when persisted child data differs from the parent default or becomes non-empty, so hidden-by-default UI does not bury meaningful edits.
+- When the old UX relied on an always-available first row, normalize child-row state to one trailing placeholder entry instead of adding a large explicit “Add” button; prune fully blank extra rows back out on edit.
+
+## Examples
+
+- `src/Frontend.elm`: spending dialog keeps a spending-level default date, but each credit/debit line owns its own date and optional secondary description.
+- `src/Frontend.elm`: the spending dialog keeps one placeholder debitor/creditor row in state so the editor behaves like the older inline-add flow without changing the persisted transaction payload.
+- `src/Backend.elm`: spending validation checks `credits = debits = spending total`, while persisted transactions stay one-sided.
+
+## Anti-Patterns
+
+- Introducing fake bucket totals just because the UI groups rows visually.
+- Pushing convenience-only parent fields into persisted child records when they are not true storage ownership.
+- Adding IDs or visibility flags to persisted line payloads just to support frontend reveal/collapse behavior.
+- Requiring users to press a large “Add” button just to create the first or next line when the older editor pattern already supported progressive row creation.

--- a/.squad/skills/lightweight-row-details/SKILL.md
+++ b/.squad/skills/lightweight-row-details/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: "lightweight-row-details"
+description: "Keep editable rows compact while auto-revealing meaningful per-row details"
+domain: "ui-contracts"
+confidence: "medium"
+source: "earned"
+---
+
+## Context
+
+Use this when each row owns real persisted detail fields, but the fully expanded form is visually heavier than the common editing path.
+
+## Patterns
+
+- Put the primary row fields first so scanning and quick edits happen without opening secondary controls.
+- When a row needs an identity cue like “Debitor 1”, prefer making that the visible label of the primary field instead of adding a separate mini-header above the row.
+- Hide secondary controls behind an explicit reveal affordance for default/empty rows.
+- Auto-show the secondary controls whenever persisted detail data is already meaningful (for example a custom date or non-empty secondary description).
+- Prefer an explicit helper that compares each row against the parent default, so the auto-reveal rule stays aligned with the same default-propagation seam that updates untouched rows.
+- Keep reveal state frontend-local; do not push presentation-only flags into backend contracts.
+- If generic icon packages do not match the semantics of compact row controls, a tiny local inline-SVG helper can be cleaner than adding a dependency with the wrong visual language.
+- When a revealed detail row mirrors the primary row semantically, keep both rows on the same width contract across breakpoints instead of letting the detail row stretch wider.
+- A practical Elm UI split is: desktop uses one flexible field plus one compact fixed-width field; small screens switch both paired fields to equal `fillPortion` widths.
+- If two labeled controls need to match as whole blocks, put the shared width on an outer `el` wrapper and let the inner `Input` or `DatePicker.input` use `width fill`; this avoids component-specific label/layout differences from breaking alignment.
+- If sibling row lists share a normalization pass, keep passive normalization from auto-seeding placeholder values on the untouched side; only the side the user is actively adding should receive any convenience default.
+
+## Examples
+
+- `src/Frontend.elm`: spending lines now show group and amount inline, while per-line date and secondary description stay collapsed unless revealed or already customized.
+- `src/Frontend.elm`: spending rows use the group field label (`Debitor 1`, `Creditor 1`) as the row identifier, with compact inline SVG controls for details/remove.
+- `src/Frontend.elm`: the spending dialog now shares the same desktop/small-screen width split between `Group/Amount` and `Description/Date`, so expanding details does not widen the visual grid.
+- `src/Frontend.elm`: wrapping both the amount field and the date picker in width-constrained `el` blocks keeps the full `Amount + field` and `Date + field` columns aligned, not just the inner inputs.
+- `src/Frontend.elm`: `normalizeSpendingDialogLines` should use `normalizeTransactionLinesWithoutAutofill` for passive cleanup, so typing on debitors cannot silently prefill creditor amounts.
+
+## Anti-Patterns
+
+- Forcing every row into a card-style expanded layout when most rows use defaults.
+- Letting users hide customized detail fields so far that meaningful differences from the parent default disappear.
+- Using a separate bold row title and a hidden primary-field label when one visible field label would carry the same meaning with less visual noise.
+- Giving the secondary row more horizontal budget than the primary row, or letting compact fields like dates grow wider than their amount counterparts.
+- Applying width only to the inner control when the surrounding labeled block is what needs to align across different component types.
+- Reusing an autofill-oriented normalizer for both debit and credit lists after every keystroke, which can leak placeholder amounts into the opposite untouched side.

--- a/.squad/skills/model-review-gates/SKILL.md
+++ b/.squad/skills/model-review-gates/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: "model-review-gates"
+description: "Review checklist for compile-first Lamdera model refactors"
+domain: "review"
+confidence: "medium"
+source: "repo-observed"
+---
+
+## Pattern
+
+For shared-model refactors, do not accept compile success by itself. Verify three seams explicitly:
+
+1. **Identifier continuity:** compare the new shared type against the last Evergreen type when the user says an identifier shape must stay stable.
+2. **Constructor fan-out:** inspect backend creation/edit paths to confirm the intended storage expansion actually happens, rather than just renaming containers.
+3. **Migration discipline:** confirm no new Evergreen files appear when the user has asked to defer migration work until after review.
+4. **Mirrored invariant cleanup:** when an invariant moves to a parent record, inspect both backend validation and frontend submit gating for leftover child-level equality checks.
+
+## Applied here
+
+- `src/Evergreen/V24/Types.elm` preserved the old `TransactionId` locator shape, which made the regression in `src/Types.elm` easy to catch.
+- `src/Backend.elm` showed the real invariant in `validateSpendingTransactions` and `createSpendingInModel`, proving the model still stores balanced buckets instead of one-sided transactions.
+- Phase 2 follow-up proved the same bug can survive in two layers at once: `validateSpendingTransactions` and `canSubmitSpending` / `validTransactionLines` both need review when `Spending.total` becomes the only amount-level invariant.
+- **Applied correction:** When a dated list index is the user-approved identifier shape, keep the list append-only and use status flags plus aggregate rollback instead of physically removing records; reconstruct higher-level edit payloads from grouped low-level transactions rather than changing the Phase 1 UI contract early.
+
+## Examples
+
+- Spending-level invariant repairs belong in the backend seam that sees the full normalized transaction list. In this repo, `src/Backend.elm:validateSpendingTransactions` is the review point for `sum(credits) = sum(debits) = spending.total`; line validation should stay limited to line completeness unless the user explicitly asks for mirrored frontend gating.
+
+## Anti-Patterns
+
+- Do not "fix" a spending-level invariant regression by reintroducing old bucket-level equality rules. If the contract says totals live on `Spending`, restore the aggregate check after normalization and leave line-level date/description shape alone.

--- a/.squad/skills/project-conventions/SKILL.md
+++ b/.squad/skills/project-conventions/SKILL.md
@@ -2,55 +2,37 @@
 name: "project-conventions"
 description: "Core conventions and patterns for this codebase"
 domain: "project-conventions"
-confidence: "medium"
-source: "template"
+confidence: "high"
+source: "repo-observed"
 ---
 
 ## Context
 
-> **This is a starter template.** Replace the placeholder patterns below with your actual project conventions. Skills train agents on codebase-specific practices — accurate documentation here improves agent output quality.
+Lamdera changes in this repo usually flow through `src/Types.elm`, `src/Backend.elm`, `src/Codecs.elm(.stub)`, and a generated Evergreen version under `src/Evergreen/`.
 
 ## Patterns
 
-### [Pattern Name]
+### Lamdera model migrations
 
-Describe a key convention or practice used in this codebase. Be specific about what to do and why.
+- Treat backend storage changes as migration work, not just type edits.
+- After changing shared types, run `lamdera check --force` to generate the new Evergreen version, then replace generated `Unimplemented` placeholders with explicit migrations.
+- Prefer rebuilding new backend storage from old persisted data rather than trying to preserve fragile positional identifiers.
 
-### Error Handling
+### Spending and transaction persistence
 
-<!-- Example: How does your project handle errors? -->
-<!-- - Use try/catch with specific error types? -->
-<!-- - Log to a specific service? -->
-<!-- - Return error objects vs throwing? -->
+- Spendings are the editable root record; dated transactions are the listed unit.
+- Keep stable integer `SpendingId`/`TransactionId` counters on `BackendModel` and store bidirectional references (`Spending.transactionIds`, `Transaction.spendingId`).
+- When editing, follow the existing append-only pattern: mark old records `Replaced`, remove their aggregate effects, then create fresh active records.
+- When the UI is still single-bucket, adapt it through a singleton default transaction and reject edits for multi-transaction spendings rather than silently collapsing data.
+- When the dialog still edits credits and debits as lists, fan them out into one-sided transaction records before persistence and rebuild bucket-level totals or member metadata in the backend from the dated transaction key.
 
-### Testing
+### Code generation and validation
 
-<!-- Example: What test framework? Where do tests live? How to run them? -->
-<!-- - Test framework: Jest/Vitest/node:test/etc. -->
-<!-- - Test location: test/, __tests__/, *.test.ts, etc. -->
-<!-- - Run command: npm test, etc. -->
-
-### Code Style
-
-<!-- Example: Linting, formatting, naming conventions -->
-<!-- - Linter: ESLint config? -->
-<!-- - Formatter: Prettier? -->
-<!-- - Naming: camelCase, snake_case, etc.? -->
-
-### File Structure
-
-<!-- Example: How is the project organized? -->
-<!-- - src/ — Source code -->
-<!-- - test/ — Tests -->
-<!-- - docs/ — Documentation -->
-
-## Examples
-
-```
-// Add code examples that demonstrate your conventions
-```
+- Regenerate codecs with `./check-codecs.sh --regenerate` after backend model changes.
+- Treat `./check-codecs.sh` as a hard review gate: Lamdera can still compile while `src/Codecs.elm` is stale relative to the generated output.
+- Format with `elm-format src/ --yes` and validate with `lamdera make src/Frontend.elm --output=/dev/null`, `lamdera make src/Backend.elm --output=/dev/null`, and `lamdera check --force`.
 
 ## Anti-Patterns
 
-<!-- List things to avoid in this codebase -->
-- **[Anti-pattern]** — Explanation of what not to do and why.
+- Do not hand-edit `src/Evergreen/V*/Types.elm`; generate it through Lamdera.
+- Do not rely on day-list positions as durable cross-record identifiers once records reference each other.

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -1,19 +1,59 @@
 # Squad Team
 
-> accounting
+> Lamdera Elm app for shared-expense accounting and debt tracking.
 
 ## Coordinator
 
 | Name | Role | Notes |
 |------|------|-------|
-| Squad | Coordinator | Routes work, enforces handoffs and reviewer gates. |
+| Squad | Coordinator | Routes work, enforces handoffs and reviewer gates. Does not generate domain artifacts. |
 
 ## Members
 
 | Name | Role | Charter | Status |
 |------|------|---------|--------|
+| Ripley | Lead | `.squad/agents/ripley/charter.md` | ✅ Active |
+| Hicks | Frontend Dev | `.squad/agents/hicks/charter.md` | ✅ Active |
+| Bishop | Backend Dev | `.squad/agents/bishop/charter.md` | ✅ Active |
+| Newt | Full-Stack Dev | `.squad/agents/newt/charter.md` | ✅ Active |
+| Hudson | Full-Stack Dev | `.squad/agents/hudson/charter.md` | ✅ Active |
+| Dallas | Full-Stack Dev | `.squad/agents/dallas/charter.md` | ✅ Active |
+| Vasquez | Tester | `.squad/agents/vasquez/charter.md` | ✅ Active |
+| Scribe | Session Logger | `.squad/agents/scribe/charter.md` | 📋 Silent |
+| Ralph | Work Monitor | — | 🔄 Monitor |
+
+## Coding Agent
+
+<!-- copilot-auto-assign: false -->
+
+| Name | Role | Charter | Status |
+|------|------|---------|--------|
+| @copilot | Coding Agent | — | 🤖 Coding Agent |
+
+### Capabilities
+
+**🟢 Good fit — auto-route when enabled:**
+- Bug fixes with clear reproduction steps
+- Test coverage additions and flaky test fixes
+- Small isolated Elm features with clear acceptance criteria
+- Dependency and tooling maintenance
+- Documentation and README updates
+
+**🟡 Needs review — route to @copilot but flag for squad member PR review:**
+- Medium-sized refactors following established patterns
+- Well-defined data migrations
+- Backend or frontend additions with explicit specs
+
+**🔴 Not suitable — route to squad member instead:**
+- Architecture and model design decisions
+- Ambiguous UX or product scope
+- Security-sensitive or permission-sensitive changes
+- Cross-cutting changes requiring coordinated frontend/backend/migration work
 
 ## Project Context
 
+- **Owner:** Théo Zimmermann
 - **Project:** accounting
+- **Stack:** Elm, Lamdera, elm-ui, elm-review, elm-format
+- **Description:** Full-stack group expense and accounting app with shared models, backend logic, and Elm UI.
 - **Created:** 2026-04-19

--- a/src/Backend.elm
+++ b/src/Backend.elm
@@ -1,5 +1,6 @@
 module Backend exposing (..)
 
+import Array exposing (Array)
 import Basics.Extra exposing (flip)
 import Codecs
 import Dict exposing (Dict)
@@ -15,6 +16,21 @@ type alias Model =
     BackendModel
 
 
+type alias PendingTransaction =
+    { spendingId : SpendingId
+    , year : Int
+    , month : Int
+    , day : Int
+    , secondaryDescription : String
+    , group : String
+    , amount : Amount ()
+    , side : TransactionSide
+    , groupMembersKey : String
+    , groupMembers : Set String
+    , status : TransactionStatus
+    }
+
+
 app =
     Lamdera.backend
         { init = init
@@ -27,10 +43,12 @@ app =
 init : ( Model, Cmd BackendMsg )
 init =
     ( { years = Dict.empty
+      , spendings = Array.empty
       , groups = Dict.empty
       , totalGroupCredits = Dict.empty
       , persons = Dict.empty
       , nextPersonId = 0
+      , nextSpendingId = 0
       , loggedInSessions = Set.empty
       }
     , Cmd.none
@@ -107,130 +125,72 @@ updateFromFrontend sessionId clientId msg model =
                 , Lamdera.sendToFrontend clientId (NameAlreadyExists name)
                 )
 
-        ( True, CreateSpending { description, year, month, day, total, credits, debits } ) ->
-            let
-                groupMembersKey =
-                    getGroupMembersKey credits debits model
+        ( True, CreateSpending { description, total, transactions } ) ->
+            case validateSpendingTransactions total transactions of
+                Err errorMessage ->
+                    ( model, Lamdera.sendToFrontend clientId (SpendingError errorMessage) )
 
-                spending =
-                    { description = description
-                    , total = total
-                    , credits = credits
-                    , debits = debits
-                    , status = Active
-                    }
+                Ok normalizedTransactions ->
+                    ( createSpendingInModel description total normalizedTransactions model
+                    , Lamdera.sendToFrontend clientId OperationSuccessful
+                    )
 
-                updatedModel =
-                    addSpendingToModel year month day spending model
-            in
-            ( updatedModel, Lamdera.sendToFrontend clientId OperationSuccessful )
-
-        ( True, EditTransaction { transactionId, description, year, month, day, total, credits, debits } ) ->
-            -- First, validate that the transaction exists and is active
-            case findTransaction transactionId model of
+        ( True, EditSpending { spendingId, description, total, transactions } ) ->
+            case Array.get spendingId model.spendings of
                 Nothing ->
-                    ( model, Lamdera.sendToFrontend clientId (TransactionError "Transaction not found") )
+                    ( model, Lamdera.sendToFrontend clientId (SpendingError "Spending not found") )
 
-                Just oldTransaction ->
-                    if oldTransaction.status /= Active then
-                        ( model, Lamdera.sendToFrontend clientId (TransactionError "Transaction is already deleted or replaced") )
+                Just spending ->
+                    if spending.status /= Active then
+                        ( model, Lamdera.sendToFrontend clientId (SpendingError "Spending is already deleted or replaced") )
 
                     else
-                        -- Valid edit: delete old, add new
-                        let
-                            -- Mark old transaction as replaced
-                            updateSpending : Int -> Spending -> Spending
-                            updateSpending index spending =
-                                if index == transactionId.index then
-                                    { spending | status = Replaced }
+                        case validateSpendingTransactions total transactions of
+                            Err errorMessage ->
+                                ( model, Lamdera.sendToFrontend clientId (SpendingError errorMessage) )
 
-                                else
-                                    spending
+                            Ok normalizedTransactions ->
+                                let
+                                    activeTransactions =
+                                        getSpendingTransactions spendingId model
+                                            |> List.filter (\transaction -> transaction.status == Active)
 
-                            updateDay : Day -> Day
-                            updateDay oldDay =
-                                { oldDay | spendings = List.indexedMap updateSpending oldDay.spendings }
+                                    cleanedModel =
+                                        List.foldl
+                                            removeTransactionFromModel
+                                            (model
+                                                |> setSpendingStatus spendingId Replaced
+                                                |> setTransactionStatuses spendingId Replaced
+                                            )
+                                            activeTransactions
+                                in
+                                ( createSpendingInModel description total normalizedTransactions cleanedModel
+                                , Lamdera.sendToFrontend clientId OperationSuccessful
+                                )
 
-                            updateMonth : Month -> Month
-                            updateMonth oldMonth =
-                                { oldMonth
-                                    | days = Dict.update transactionId.day (Maybe.map updateDay) oldMonth.days
-                                }
-
-                            updateYear : Year -> Year
-                            updateYear oldYear =
-                                { oldYear
-                                    | months = Dict.update transactionId.month (Maybe.map updateMonth) oldYear.months
-                                }
-
-                            -- Create new spending
-                            newSpending =
-                                { description = description
-                                , total = total
-                                , credits = credits
-                                , debits = debits
-                                , status = Active
-                                }
-
-                            -- Step 1: Remove old transaction from totals
-                            modelWithReplaced =
-                                { model
-                                    | years = Dict.update transactionId.year (Maybe.map updateYear) model.years
-                                }
-                                    |> removeSpendingFromModel transactionId oldTransaction
-
-                            -- Step 2: Add new transaction
-                            finalModel =
-                                addSpendingToModel year month day newSpending modelWithReplaced
-                        in
-                        ( finalModel, Lamdera.sendToFrontend clientId OperationSuccessful )
-
-        ( True, DeleteTransaction transactionId ) ->
-            -- First, validate that the transaction exists and is active
-            case findTransaction transactionId model of
+        ( True, DeleteSpending spendingId ) ->
+            case Array.get spendingId model.spendings of
                 Nothing ->
-                    ( model, Lamdera.sendToFrontend clientId (TransactionError "Transaction not found") )
+                    ( model, Lamdera.sendToFrontend clientId (SpendingError "Spending not found") )
 
-                Just transaction ->
-                    if transaction.status /= Active then
-                        ( model, Lamdera.sendToFrontend clientId (TransactionError "Transaction is already deleted or replaced") )
+                Just spending ->
+                    if spending.status /= Active then
+                        ( model, Lamdera.sendToFrontend clientId (SpendingError "Spending is already deleted or replaced") )
 
                     else
-                        -- Valid delete: mark as deleted and remove from totals
                         let
-                            updateSpending : Int -> Spending -> Spending
-                            updateSpending index spending =
-                                if index == transactionId.index then
-                                    { spending | status = Deleted }
+                            activeTransactions =
+                                getSpendingTransactions spendingId model
+                                    |> List.filter (\transaction -> transaction.status == Active)
 
-                                else
-                                    spending
-
-                            updateDay : Day -> Day
-                            updateDay day =
-                                { day | spendings = List.indexedMap updateSpending day.spendings }
-
-                            updateMonth : Month -> Month
-                            updateMonth month =
-                                { month
-                                    | days = Dict.update transactionId.day (Maybe.map updateDay) month.days
-                                }
-
-                            updateYear : Year -> Year
-                            updateYear year =
-                                { year
-                                    | months = Dict.update transactionId.month (Maybe.map updateMonth) year.months
-                                }
-
-                            -- Mark transaction as deleted
-                            modelWithDeleted =
-                                { model
-                                    | years = Dict.update transactionId.year (Maybe.map updateYear) model.years
-                                }
-
-                            -- Remove from totals
                             finalModel =
-                                removeSpendingFromModel transactionId transaction modelWithDeleted
+                                List.foldl
+                                    removeTransactionFromModel
+                                    (model
+                                        |> setSpendingStatus spendingId Deleted
+                                        |> setTransactionStatuses spendingId Deleted
+                                    )
+                                    activeTransactions
                         in
                         ( finalModel, Lamdera.sendToFrontend clientId OperationSuccessful )
 
@@ -248,30 +208,35 @@ updateFromFrontend sessionId clientId msg model =
                 |> autocomplete clientId prefix AutocompleteGroupPrefix InvalidGroupPrefix
             )
 
-        ( True, RequestTransactionDetails transactionId ) ->
-            case findTransaction transactionId model of
+        ( True, RequestSpendingDetails spendingId ) ->
+            case Array.get spendingId model.spendings of
                 Nothing ->
-                    ( model, Lamdera.sendToFrontend clientId (TransactionError "Transaction not found") )
+                    ( model, Lamdera.sendToFrontend clientId (SpendingError "Spending not found") )
 
-                Just transaction ->
-                    if transaction.status /= Active then
-                        ( model, Lamdera.sendToFrontend clientId (TransactionError "Transaction is not active") )
+                Just spending ->
+                    if spending.status /= Active then
+                        ( model, Lamdera.sendToFrontend clientId (SpendingError "Spending is not active") )
 
                     else
-                        ( model
-                        , Lamdera.sendToFrontend clientId
-                            (TransactionDetails
-                                { transactionId = transactionId
-                                , description = transaction.description
-                                , year = transactionId.year
-                                , month = transactionId.month
-                                , day = transactionId.day
-                                , total = transaction.total
-                                , credits = transaction.credits
-                                , debits = transaction.debits
-                                }
-                            )
-                        )
+                        let
+                            spendingTransactions =
+                                spendingTransactionsForDetails spendingId model
+                        in
+                        case spendingTransactions of
+                            [] ->
+                                ( model, Lamdera.sendToFrontend clientId (SpendingError "Spending has no active transactions") )
+
+                            _ ->
+                                ( model
+                                , Lamdera.sendToFrontend clientId
+                                    (SpendingDetails
+                                        { spendingId = spendingId
+                                        , description = spending.description
+                                        , total = spending.total
+                                        , transactions = spendingTransactions
+                                        }
+                                    )
+                                )
 
         ( True, RequestUserGroups user ) ->
             case Dict.get user model.persons of
@@ -330,72 +295,13 @@ updateFromFrontend sessionId clientId msg model =
             let
                 transactions =
                     Dict.foldr
-                        (\year { months } accYears ->
+                        (\_ { months } accYears ->
                             Dict.foldr
-                                (\month { days } accMonths ->
+                                (\_ { days } accMonths ->
                                     Dict.foldr
-                                        (\day { spendings } accDays ->
-                                            List.indexedMap
-                                                (\index spending ->
-                                                    if spending.status == Active then
-                                                        -- Look for the group in both credits and debits
-                                                        case ( Dict.get group spending.credits, Dict.get group spending.debits ) of
-                                                            ( Just credit, Nothing ) ->
-                                                                Just
-                                                                    { transactionId =
-                                                                        { year = year
-                                                                        , month = month
-                                                                        , day = day
-                                                                        , index = index
-                                                                        }
-                                                                    , description = spending.description
-                                                                    , year = year
-                                                                    , month = month
-                                                                    , day = day
-                                                                    , total = (\(Amount a) -> Amount a) spending.total
-                                                                    , share = toDebit credit
-                                                                    }
-
-                                                            ( Nothing, Just debit ) ->
-                                                                Just
-                                                                    { transactionId =
-                                                                        { year = year
-                                                                        , month = month
-                                                                        , day = day
-                                                                        , index = index
-                                                                        }
-                                                                    , description = spending.description
-                                                                    , year = year
-                                                                    , month = month
-                                                                    , day = day
-                                                                    , total = (\(Amount a) -> Amount a) spending.total
-                                                                    , share = debit
-                                                                    }
-
-                                                            ( Just credit, Just debit ) ->
-                                                                Just
-                                                                    { transactionId =
-                                                                        { year = year
-                                                                        , month = month
-                                                                        , day = day
-                                                                        , index = index
-                                                                        }
-                                                                    , description = spending.description
-                                                                    , year = year
-                                                                    , month = month
-                                                                    , day = day
-                                                                    , total = (\(Amount a) -> Amount a) spending.total
-                                                                    , share = addAmountToAmount (toDebit credit) debit
-                                                                    }
-
-                                                            ( Nothing, Nothing ) ->
-                                                                Nothing
-
-                                                    else
-                                                        Nothing
-                                                )
-                                                spendings
-                                                |> List.filterMap identity
+                                        (\_ dayRecord accDays ->
+                                            dayRecord.transactions
+                                                |> List.filterMap (groupTransactionForList model group)
                                                 |> (++) accDays
                                         )
                                         accMonths
@@ -536,13 +442,37 @@ addToTotalGroupCredits groupMembersKey groupCredits =
         )
 
 
-addSpendingToYear : Int -> Int -> String -> Dict String (Amount Credit) -> Spending -> Maybe Year -> Year
-addSpendingToYear month day groupMembersKey groupCredits spending maybeYear =
+listGet : Int -> List a -> Maybe a
+listGet index list =
+    list
+        |> List.drop index
+        |> List.head
+
+
+findTransaction : TransactionId -> Model -> Maybe Transaction
+findTransaction transactionId model =
+    Dict.get transactionId.year model.years
+        |> Maybe.andThen (.months >> Dict.get transactionId.month)
+        |> Maybe.andThen (.days >> Dict.get transactionId.day)
+        |> Maybe.andThen (.transactions >> listGet transactionId.index)
+
+
+dayTransactionCount : Int -> Int -> Int -> Model -> Int
+dayTransactionCount year month day model =
+    Dict.get year model.years
+        |> Maybe.andThen (.months >> Dict.get month)
+        |> Maybe.andThen (.days >> Dict.get day)
+        |> Maybe.map (.transactions >> List.length)
+        |> Maybe.withDefault 0
+
+
+addTransactionToYear : Transaction -> String -> Dict String (Amount Credit) -> Maybe Year -> Year
+addTransactionToYear transaction groupMembersKey groupCredits maybeYear =
     case maybeYear of
         Nothing ->
             { months =
-                Dict.singleton month
-                    (addSpendingToMonth day groupMembersKey groupCredits spending Nothing)
+                Dict.singleton transaction.id.month
+                    (addTransactionToMonth transaction groupMembersKey groupCredits Nothing)
             , totalGroupCredits =
                 Dict.singleton groupMembersKey groupCredits
             }
@@ -550,20 +480,20 @@ addSpendingToYear month day groupMembersKey groupCredits spending maybeYear =
         Just year ->
             { months =
                 year.months
-                    |> Dict.update month (addSpendingToMonth day groupMembersKey groupCredits spending >> Just)
+                    |> Dict.update transaction.id.month (addTransactionToMonth transaction groupMembersKey groupCredits >> Just)
             , totalGroupCredits =
                 year.totalGroupCredits
                     |> addToTotalGroupCredits groupMembersKey groupCredits
             }
 
 
-addSpendingToMonth : Int -> String -> Dict String (Amount Credit) -> Spending -> Maybe Month -> Month
-addSpendingToMonth day groupMembersKey groupCredits spending maybeMonth =
+addTransactionToMonth : Transaction -> String -> Dict String (Amount Credit) -> Maybe Month -> Month
+addTransactionToMonth transaction groupMembersKey groupCredits maybeMonth =
     case maybeMonth of
         Nothing ->
             { days =
-                Dict.singleton day
-                    (addSpendingToDay groupMembersKey groupCredits spending Nothing)
+                Dict.singleton transaction.id.day
+                    (addTransactionToDay transaction groupMembersKey groupCredits Nothing)
             , totalGroupCredits =
                 Dict.singleton groupMembersKey groupCredits
             }
@@ -571,134 +501,300 @@ addSpendingToMonth day groupMembersKey groupCredits spending maybeMonth =
         Just month ->
             { days =
                 month.days
-                    |> Dict.update day (addSpendingToDay groupMembersKey groupCredits spending >> Just)
+                    |> Dict.update transaction.id.day (addTransactionToDay transaction groupMembersKey groupCredits >> Just)
             , totalGroupCredits =
                 month.totalGroupCredits
                     |> addToTotalGroupCredits groupMembersKey groupCredits
             }
 
 
-addSpendingToDay : String -> Dict String (Amount Credit) -> Spending -> Maybe Day -> Day
-addSpendingToDay groupMembersKey groupCredits spending maybeDay =
+addTransactionToDay : Transaction -> String -> Dict String (Amount Credit) -> Maybe Day -> Day
+addTransactionToDay transaction groupMembersKey groupCredits maybeDay =
     case maybeDay of
         Nothing ->
-            { spendings = [ spending ]
+            { transactions = [ transaction ]
             , totalGroupCredits =
                 Dict.singleton groupMembersKey groupCredits
             }
 
         Just day ->
-            { spendings = spending :: day.spendings
+            { transactions = transaction :: day.transactions
             , totalGroupCredits =
                 day.totalGroupCredits
                     |> addToTotalGroupCredits groupMembersKey groupCredits
             }
 
 
-{-| Remove spending amount from the hierarchy totals. Used for deletes and edits.
--}
-removeSpendingFromYear : Int -> Int -> String -> Dict String (Amount Credit) -> Maybe Year -> Maybe Year
-removeSpendingFromYear month day groupMembersKey groupCredits maybeYear =
+removeTransactionFromYear : Transaction -> String -> Dict String (Amount Credit) -> Maybe Year -> Maybe Year
+removeTransactionFromYear transaction groupMembersKey groupCredits maybeYear =
     case maybeYear of
         Nothing ->
             Nothing
 
         Just year ->
-            let
-                updatedMonths =
+            Just
+                { months =
                     year.months
-                        |> Dict.update month (removeSpendingFromMonth day groupMembersKey groupCredits)
-
-                updatedTotalGroupCredits =
+                        |> Dict.update transaction.id.month (removeTransactionFromMonth transaction groupMembersKey groupCredits)
+                , totalGroupCredits =
                     year.totalGroupCredits
                         |> addToTotalGroupCredits groupMembersKey groupCredits
-            in
-            Just
-                { months = updatedMonths
-                , totalGroupCredits = updatedTotalGroupCredits
                 }
 
 
-removeSpendingFromMonth : Int -> String -> Dict String (Amount Credit) -> Maybe Month -> Maybe Month
-removeSpendingFromMonth day groupMembersKey groupCredits maybeMonth =
+removeTransactionFromMonth : Transaction -> String -> Dict String (Amount Credit) -> Maybe Month -> Maybe Month
+removeTransactionFromMonth transaction groupMembersKey groupCredits maybeMonth =
     case maybeMonth of
         Nothing ->
             Nothing
 
         Just month ->
-            let
-                updatedDays =
+            Just
+                { days =
                     month.days
-                        |> Dict.update day (removeSpendingFromDay groupMembersKey groupCredits)
-
-                updatedTotalGroupCredits =
+                        |> Dict.update transaction.id.day (removeTransactionFromDay groupMembersKey groupCredits)
+                , totalGroupCredits =
                     month.totalGroupCredits
                         |> addToTotalGroupCredits groupMembersKey groupCredits
-            in
-            Just
-                { days = updatedDays
-                , totalGroupCredits = updatedTotalGroupCredits
                 }
 
 
-removeSpendingFromDay : String -> Dict String (Amount Credit) -> Maybe Day -> Maybe Day
-removeSpendingFromDay groupMembersKey groupCredits maybeDay =
+removeTransactionFromDay : String -> Dict String (Amount Credit) -> Maybe Day -> Maybe Day
+removeTransactionFromDay groupMembersKey groupCredits maybeDay =
     case maybeDay of
         Nothing ->
             Nothing
 
         Just day ->
-            let
-                updatedTotalGroupCredits =
+            Just
+                { transactions = day.transactions
+                , totalGroupCredits =
                     day.totalGroupCredits
                         |> addToTotalGroupCredits groupMembersKey groupCredits
-            in
-            Just
-                { spendings = day.spendings
-                , totalGroupCredits = updatedTotalGroupCredits
                 }
 
 
-{-| Find a specific transaction by ID
--}
-findTransaction : TransactionId -> Model -> Maybe Spending
-findTransaction transactionId model =
-    model.years
-        |> Dict.get transactionId.year
-        |> Maybe.andThen (.months >> Dict.get transactionId.month)
-        |> Maybe.andThen (.days >> Dict.get transactionId.day)
-        |> Maybe.andThen (.spendings >> List.drop transactionId.index >> List.head)
-
-
-{-| Get group members key for a spending
--}
-getGroupMembersKey : Dict String (Amount Credit) -> Dict String (Amount Debit) -> Model -> String
-getGroupMembersKey credits debits model =
+validateSpendingTransactions : Amount Credit -> List SpendingTransaction -> Result String (List SpendingTransaction)
+validateSpendingTransactions (Amount total) transactions =
     let
-        groupMembers =
-            (Dict.keys credits ++ Dict.keys debits)
-                |> List.map
-                    (\group ->
-                        Dict.get group model.groups
-                            |> Maybe.map Dict.keys
-                            |> Maybe.withDefault [ group ]
-                    )
-                |> List.concat
-                |> Set.fromList
+        normalizedTransactions =
+            normalizeSpendingTransactions transactions
+
+        { credits, debits } =
+            spendingTransactionTotals normalizedTransactions
     in
-    Set.toList groupMembers
-        |> List.filterMap (flip Dict.get model.persons)
-        |> List.map (.id >> String.fromInt)
-        |> String.join ","
+    if List.isEmpty normalizedTransactions then
+        Err "A spending needs at least one transaction"
+
+    else if
+        List.all isBalancedTransaction normalizedTransactions
+            && credits
+            == debits
+            && credits
+            == total
+            && total
+            > 0
+    then
+        Ok normalizedTransactions
+
+    else
+        Err "Spending total must match total credits and total debits"
 
 
-{-| Get group members key for an existing spending
--}
-getGroupMembersKeyForSpending : Spending -> Model -> ( String, Set String )
-getGroupMembersKeyForSpending spending model =
+normalizeSpendingTransactions : List SpendingTransaction -> List SpendingTransaction
+normalizeSpendingTransactions transactions =
+    transactions
+        |> List.foldl
+            (\transaction ->
+                Dict.update
+                    (normalizedTransactionKey transaction)
+                    (\maybeTransaction ->
+                        case maybeTransaction of
+                            Nothing ->
+                                Just transaction
+
+                            Just existingTransaction ->
+                                Just
+                                    { existingTransaction
+                                        | amount = addAmountToAmount existingTransaction.amount transaction.amount
+                                    }
+                    )
+            )
+            Dict.empty
+        |> Dict.values
+        |> List.filter
+            (\transaction ->
+                case transaction.amount of
+                    Amount amount ->
+                        amount > 0
+            )
+
+
+isBalancedTransaction : SpendingTransaction -> Bool
+isBalancedTransaction transaction =
+    case transaction.amount of
+        Amount amount ->
+            String.trim transaction.group
+                /= ""
+                && amount
+                > 0
+
+
+totalAmount : Dict String (Amount a) -> Int
+totalAmount =
+    Dict.values
+        >> List.foldl (\(Amount amount) total -> total + amount) 0
+
+
+toSpendingTransaction : Transaction -> SpendingTransaction
+toSpendingTransaction transaction =
+    { year = transaction.id.year
+    , month = transaction.id.month
+    , day = transaction.id.day
+    , secondaryDescription = transaction.secondaryDescription
+    , group = transaction.group
+    , amount = transaction.amount
+    , side = transaction.side
+    }
+
+
+pendingTransactionsForSpending : SpendingId -> SpendingMetadata -> SpendingTransaction -> PendingTransaction
+pendingTransactionsForSpending spendingId metadata transaction =
+    { spendingId = spendingId
+    , year = transaction.year
+    , month = transaction.month
+    , day = transaction.day
+    , secondaryDescription = transaction.secondaryDescription
+    , group = transaction.group
+    , amount = transaction.amount
+    , side = transaction.side
+    , groupMembersKey = metadata.groupMembersKey
+    , groupMembers = metadata.groupMembers
+    , status = Active
+    }
+
+
+assignTransactionIds : Model -> List PendingTransaction -> List Transaction
+assignTransactionIds model pendingTransactions =
+    pendingTransactions
+        |> List.foldl
+            (\pending ( nextIndexes, transactions ) ->
+                let
+                    dateKey =
+                        ( pending.year, pending.month, pending.day )
+
+                    nextIndex =
+                        Dict.get dateKey nextIndexes
+                            |> Maybe.withDefault (dayTransactionCount pending.year pending.month pending.day model)
+                in
+                ( Dict.insert dateKey (nextIndex + 1) nextIndexes
+                , { id =
+                        { year = pending.year
+                        , month = pending.month
+                        , day = pending.day
+                        , index = nextIndex
+                        }
+                  , spendingId = pending.spendingId
+                  , secondaryDescription = pending.secondaryDescription
+                  , group = pending.group
+                  , amount = pending.amount
+                  , side = pending.side
+                  , groupMembersKey = pending.groupMembersKey
+                  , groupMembers = pending.groupMembers
+                  , status = pending.status
+                  }
+                    :: transactions
+                )
+            )
+            ( Dict.empty, [] )
+        |> (\( _, transactions ) -> List.reverse transactions)
+
+
+createSpendingInModel : String -> Amount Credit -> List SpendingTransaction -> Model -> Model
+createSpendingInModel description total spendingTransactions model =
+    let
+        spendingId =
+            model.nextSpendingId
+
+        spendingMetadata =
+            buildSpendingMetadata model spendingTransactions
+
+        storedTransactions =
+            spendingTransactions
+                |> List.map (pendingTransactionsForSpending spendingId spendingMetadata)
+                |> assignTransactionIds model
+
+        updatedModel =
+            { model
+                | spendings =
+                    Array.push
+                        { description = description
+                        , total = total
+                        , transactionIds = List.map .id storedTransactions
+                        , status = Active
+                        }
+                        model.spendings
+                , nextSpendingId = spendingId + 1
+            }
+    in
+    List.foldl addTransactionToModel updatedModel storedTransactions
+
+
+setSpendingStatus : SpendingId -> TransactionStatus -> Model -> Model
+setSpendingStatus spendingId status model =
+    { model
+        | spendings =
+            case Array.get spendingId model.spendings of
+                Nothing ->
+                    model.spendings
+
+                Just spending ->
+                    Array.set spendingId { spending | status = status } model.spendings
+    }
+
+
+setTransactionStatuses : SpendingId -> TransactionStatus -> Model -> Model
+setTransactionStatuses spendingId status model =
+    { model
+        | years =
+            Dict.map
+                (\_ year ->
+                    { year
+                        | months =
+                            Dict.map
+                                (\_ month ->
+                                    { month
+                                        | days =
+                                            Dict.map
+                                                (\_ day ->
+                                                    { day
+                                                        | transactions =
+                                                            List.map
+                                                                (\transaction ->
+                                                                    if transaction.spendingId == spendingId && transaction.status == Active then
+                                                                        { transaction | status = status }
+
+                                                                    else
+                                                                        transaction
+                                                                )
+                                                                day.transactions
+                                                    }
+                                                )
+                                                month.days
+                                    }
+                                )
+                                year.months
+                    }
+                )
+                model.years
+    }
+
+
+getGroupMembersKey : List String -> Model -> ( String, Set String )
+getGroupMembersKey groups model =
     let
         groupMembers =
-            (Dict.keys spending.credits ++ Dict.keys spending.debits)
+            groups
                 |> List.map
                     (\group ->
                         Dict.get group model.groups
@@ -716,34 +812,108 @@ getGroupMembersKeyForSpending spending model =
     )
 
 
-{-| Add a spending to the model, updating all totals and person belongsTo sets
--}
-addSpendingToModel : Int -> Int -> Int -> Spending -> Model -> Model
-addSpendingToModel year month day spending model =
-    let
-        ( groupMembersKey, groupMembers ) =
-            getGroupMembersKeyForSpending spending model
+type alias TransactionKey =
+    ( Int, Int, ( Int, String ) )
 
-        -- Convert debits to negative credits for aggregation
+
+type alias NormalizedTransactionKey =
+    ( TransactionKey, String, String )
+
+
+transactionKey : { a | year : Int, month : Int, day : Int, secondaryDescription : String } -> TransactionKey
+transactionKey transaction =
+    ( transaction.year, transaction.month, ( transaction.day, transaction.secondaryDescription ) )
+
+
+normalizedTransactionKey : SpendingTransaction -> NormalizedTransactionKey
+normalizedTransactionKey transaction =
+    ( transactionKey transaction
+    , transaction.group
+    , case transaction.side of
+        CreditTransaction ->
+            "credit"
+
+        DebitTransaction ->
+            "debit"
+    )
+
+
+type alias SpendingTransactionTotals =
+    { credits : Int
+    , debits : Int
+    }
+
+
+spendingTransactionTotals : List SpendingTransaction -> SpendingTransactionTotals
+spendingTransactionTotals transactions =
+    transactions
+        |> List.foldl
+            (\transaction totals ->
+                case transaction.amount of
+                    Amount amount ->
+                        case transaction.side of
+                            CreditTransaction ->
+                                { totals | credits = totals.credits + amount }
+
+                            DebitTransaction ->
+                                { totals | debits = totals.debits + amount }
+            )
+            { credits = 0
+            , debits = 0
+            }
+
+
+type alias SpendingMetadata =
+    { groupMembersKey : String
+    , groupMembers : Set String
+    }
+
+
+buildSpendingMetadata : Model -> List SpendingTransaction -> SpendingMetadata
+buildSpendingMetadata model transactions =
+    let
+        groups =
+            transactions
+                |> List.map .group
+
+        ( groupMembersKey, groupMembers ) =
+            getGroupMembersKey groups model
+    in
+    { groupMembersKey = groupMembersKey
+    , groupMembers = groupMembers
+    }
+
+
+groupCreditsForTransaction : Transaction -> Dict String (Amount Credit)
+groupCreditsForTransaction transaction =
+    case ( transaction.side, transaction.amount ) of
+        ( CreditTransaction, Amount amount ) ->
+            Dict.singleton transaction.group (Amount amount)
+
+        ( DebitTransaction, Amount amount ) ->
+            Dict.singleton transaction.group (Amount -amount)
+
+
+addTransactionToModel : Transaction -> Model -> Model
+addTransactionToModel transaction model =
+    let
         groupCredits =
-            spending.debits
-                |> Dict.map (\_ (Amount amount) -> Amount -amount)
-                |> addAmounts spending.credits
+            groupCreditsForTransaction transaction
     in
     { model
         | years =
             model.years
-                |> Dict.update year (addSpendingToYear month day groupMembersKey groupCredits spending >> Just)
+                |> Dict.update transaction.id.year (addTransactionToYear transaction transaction.groupMembersKey groupCredits >> Just)
         , totalGroupCredits =
             model.totalGroupCredits
-                |> addToTotalGroupCredits groupMembersKey groupCredits
+                |> addToTotalGroupCredits transaction.groupMembersKey groupCredits
         , persons =
             Dict.map
                 (\name person ->
-                    if Set.member name groupMembers then
+                    if Set.member name transaction.groupMembers then
                         { person
                             | belongsTo =
-                                Set.insert groupMembersKey person.belongsTo
+                                Set.insert transaction.groupMembersKey person.belongsTo
                         }
 
                     else
@@ -753,26 +923,94 @@ addSpendingToModel year month day spending model =
     }
 
 
-{-| Remove a spending from the model totals (but keep the spending record marked as deleted)
--}
-removeSpendingFromModel : TransactionId -> Spending -> Model -> Model
-removeSpendingFromModel transactionId spending model =
+removeTransactionFromModel : Transaction -> Model -> Model
+removeTransactionFromModel transaction model =
     let
-        ( groupMembersKey, groupMembers ) =
-            getGroupMembersKeyForSpending spending model
-
-        -- Convert debits to negative credits for aggregation and negate the whole
         groupCredits =
-            spending.debits
-                |> Dict.map (\_ (Amount amount) -> Amount -amount)
-                |> addAmounts spending.credits
+            groupCreditsForTransaction transaction
                 |> Dict.map (\_ (Amount amount) -> Amount -amount)
     in
     { model
         | years =
             model.years
-                |> Dict.update transactionId.year (removeSpendingFromYear transactionId.month transactionId.day groupMembersKey groupCredits)
+                |> Dict.update transaction.id.year (removeTransactionFromYear transaction transaction.groupMembersKey groupCredits)
         , totalGroupCredits =
             model.totalGroupCredits
-                |> addToTotalGroupCredits groupMembersKey groupCredits
+                |> addToTotalGroupCredits transaction.groupMembersKey groupCredits
     }
+
+
+getSpendingTransactions : SpendingId -> Model -> List Transaction
+getSpendingTransactions spendingId model =
+    Array.get spendingId model.spendings
+        |> Maybe.map
+            (.transactionIds
+                >> List.filterMap (\transactionId -> findTransaction transactionId model)
+            )
+        |> Maybe.withDefault []
+
+
+spendingTransactionsForDetails : SpendingId -> Model -> List SpendingTransaction
+spendingTransactionsForDetails spendingId model =
+    getSpendingTransactions spendingId model
+        |> List.filter (\transaction -> transaction.status == Active)
+        |> List.sortBy (\transaction -> ( transaction.id.year, transaction.id.month, ( transaction.id.day, transaction.id.index ) ))
+        |> List.map toSpendingTransaction
+
+
+transactionDescription : Spending -> Transaction -> String
+transactionDescription spending transaction =
+    if String.trim transaction.secondaryDescription == "" then
+        spending.description
+
+    else
+        spending.description ++ " — " ++ transaction.secondaryDescription
+
+
+groupTransactionForList :
+    Model
+    -> String
+    -> Transaction
+    ->
+        Maybe
+            { transactionId : TransactionId
+            , spendingId : SpendingId
+            , description : String
+            , year : Int
+            , month : Int
+            , day : Int
+            , total : Amount Debit
+            , share : Amount Debit
+            }
+groupTransactionForList model group transaction =
+    if transaction.status /= Active then
+        Nothing
+
+    else
+        Array.get transaction.spendingId model.spendings
+            |> Maybe.andThen
+                (\spending ->
+                    if spending.status /= Active then
+                        Nothing
+
+                    else if transaction.group /= group then
+                        Nothing
+
+                    else
+                        Just
+                            { transactionId = transaction.id
+                            , spendingId = transaction.spendingId
+                            , description = transactionDescription spending transaction
+                            , year = transaction.id.year
+                            , month = transaction.id.month
+                            , day = transaction.id.day
+                            , total = spending.total |> (\(Amount amount) -> Amount amount)
+                            , share =
+                                case ( transaction.side, transaction.amount ) of
+                                    ( CreditTransaction, Amount amount ) ->
+                                        toDebit (Amount amount)
+
+                                    ( DebitTransaction, Amount amount ) ->
+                                        Amount amount
+                            }
+                )

--- a/src/Codecs.elm
+++ b/src/Codecs.elm
@@ -14,6 +14,7 @@ If it fails, regenerate using the command above.
 
 -}
 
+import Array
 import Codec exposing (Codec)
 import Dict
 import Set
@@ -26,6 +27,9 @@ import Types
         , Person
         , Share(..)
         , Spending
+        , Transaction
+        , TransactionId
+        , TransactionSide(..)
         , TransactionStatus(..)
         , Year
         )
@@ -48,10 +52,12 @@ backendCodec =
             "years"
             .years
             (Codec.map Dict.fromList Dict.toList (Codec.list (Codec.tuple Codec.int yearCodec)))
+        |> Codec.field "spendings" .spendings (Codec.array spendingCodec)
         |> Codec.field "groups" .groups (Codec.dict (Codec.dict shareCodec))
         |> Codec.field "totalGroupCredits" .totalGroupCredits (Codec.dict (Codec.dict amountCodec))
         |> Codec.field "persons" .persons (Codec.dict personCodec)
         |> Codec.field "nextPersonId" .nextPersonId Codec.int
+        |> Codec.field "nextSpendingId" .nextSpendingId Codec.int
         |> Codec.field "loggedInSessions" .loggedInSessions (Codec.set Codec.string)
         |> Codec.buildObject
 
@@ -78,20 +84,50 @@ monthCodec =
 dayCodec : Codec Day
 dayCodec =
     Codec.object Day
-        |> Codec.field "spendings" .spendings (Codec.list spendingCodec)
+        |> Codec.field "transactions" .transactions (Codec.list transactionCodec)
         |> Codec.field "totalGroupCredits" .totalGroupCredits (Codec.dict (Codec.dict amountCodec))
         |> Codec.buildObject
 
 
-spendingCodec : Codec Spending
-spendingCodec =
-    Codec.object Spending
-        |> Codec.field "description" .description Codec.string
-        |> Codec.field "total" .total amountCodec
-        |> Codec.field "credits" .credits (Codec.dict amountCodec)
-        |> Codec.field "debits" .debits (Codec.dict amountCodec)
+transactionCodec : Codec Transaction
+transactionCodec =
+    Codec.object Transaction
+        |> Codec.field "id" .id transactionIdCodec
+        |> Codec.field "spendingId" .spendingId Codec.int
+        |> Codec.field "secondaryDescription" .secondaryDescription Codec.string
+        |> Codec.field "group" .group Codec.string
+        |> Codec.field "amount" .amount amountCodec
+        |> Codec.field "side" .side transactionSideCodec
+        |> Codec.field "groupMembersKey" .groupMembersKey Codec.string
+        |> Codec.field "groupMembers" .groupMembers (Codec.set Codec.string)
         |> Codec.field "status" .status transactionStatusCodec
         |> Codec.buildObject
+
+
+transactionIdCodec : Codec TransactionId
+transactionIdCodec =
+    Codec.object TransactionId
+        |> Codec.field "year" .year Codec.int
+        |> Codec.field "month" .month Codec.int
+        |> Codec.field "day" .day Codec.int
+        |> Codec.field "index" .index Codec.int
+        |> Codec.buildObject
+
+
+transactionSideCodec : Codec TransactionSide
+transactionSideCodec =
+    Codec.custom
+        (\creditTransactionEncoder debitTransactionEncoder value ->
+            case value of
+                Types.CreditTransaction ->
+                    creditTransactionEncoder
+
+                Types.DebitTransaction ->
+                    debitTransactionEncoder
+        )
+        |> Codec.variant0 "CreditTransaction" Types.CreditTransaction
+        |> Codec.variant0 "DebitTransaction" Types.DebitTransaction
+        |> Codec.buildCustom
 
 
 transactionStatusCodec : Codec TransactionStatus
@@ -112,6 +148,16 @@ transactionStatusCodec =
         |> Codec.variant0 "Deleted" Types.Deleted
         |> Codec.variant0 "Replaced" Types.Replaced
         |> Codec.buildCustom
+
+
+spendingCodec : Codec Spending
+spendingCodec =
+    Codec.object Spending
+        |> Codec.field "description" .description Codec.string
+        |> Codec.field "total" .total amountCodec
+        |> Codec.field "transactionIds" .transactionIds (Codec.list transactionIdCodec)
+        |> Codec.field "status" .status transactionStatusCodec
+        |> Codec.buildObject
 
 
 shareCodec : Codec Share

--- a/src/Codecs.elm.stub
+++ b/src/Codecs.elm.stub
@@ -14,6 +14,7 @@ If it fails, regenerate using the command above.
 
 -}
 
+import Array
 import Codec exposing (Codec)
 import Dict
 import Set
@@ -26,6 +27,9 @@ import Types
         , Person
         , Share(..)
         , Spending
+        , Transaction
+        , TransactionId
+        , TransactionSide(..)
         , TransactionStatus(..)
         , Year
         )

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -2352,7 +2352,7 @@ transactionLineFlexibleFieldWidth windowWidth =
 
 transactionLineCompactFieldWidth windowWidth =
     if windowWidth > 650 then
-        px 150
+        px 200
 
     else
         fillPortion 1

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -158,15 +158,15 @@ update msg model =
             , Cmd.none
             )
 
-        ShowAddSpendingDialog maybeTransactionId ->
-            case maybeTransactionId of
+        ShowAddSpendingDialog maybeReference ->
+            case maybeReference of
                 Nothing ->
                     -- Create new spending
                     ( { model
                         | showDialog =
                             Just
                                 (AddSpendingDialog
-                                    { transactionId = Nothing
+                                    { spendingId = Nothing
                                     , description = ""
                                     , date = Nothing
                                     , dateText = ""
@@ -181,13 +181,13 @@ update msg model =
                     , Task.perform SetToday Date.today
                     )
 
-                Just transactionId ->
+                Just reference ->
                     -- Edit existing transaction
-                    case List.find (\t -> t.transactionId == transactionId) model.groupTransactions of
+                    case List.find (\t -> t.transactionId == reference.transactionId) model.groupTransactions of
                         Just transaction ->
                             let
                                 date =
-                                    Date.fromCalendarDate transactionId.year (Date.numberToMonth transactionId.month) transactionId.day
+                                    Date.fromCalendarDate transaction.year (Date.numberToMonth transaction.month) transaction.day
 
                                 dateText =
                                     Date.format "yyyy-MM-dd" date
@@ -199,45 +199,72 @@ update msg model =
                                 | showDialog =
                                     Just
                                         (AddSpendingDialog
-                                            { transactionId = Just transactionId
+                                            { spendingId = Just reference.spendingId
                                             , description = transaction.description
                                             , date = Just date
                                             , dateText = dateText
                                             , datePickerModel = DatePicker.initWithToday date
                                             , total = total
-                                            , credits = [] -- Will be populated when TransactionDetails arrives
-                                            , debits = [] -- Will be populated when TransactionDetails arrives
+                                            , credits = [] -- Will be populated when SpendingDetails arrives
+                                            , debits = [] -- Will be populated when SpendingDetails arrives
                                             , submitted = False
                                             }
                                         )
                               }
                             , Cmd.batch
                                 [ Task.perform SetToday Date.today
-                                , Lamdera.sendToBackend (RequestTransactionDetails transactionId)
+                                , Lamdera.sendToBackend (RequestSpendingDetails reference.spendingId)
                                 ]
                             )
 
                         Nothing ->
                             ( model, Cmd.none )
 
-        ShowConfirmDeleteDialog transactionId ->
-            ( { model | showDialog = Just (ConfirmDeleteDialog transactionId) }, Cmd.none )
+        ShowConfirmDeleteDialog spendingId ->
+            ( { model | showDialog = Just (ConfirmDeleteDialog spendingId) }, Cmd.none )
 
-        ConfirmDeleteTransaction transactionId ->
+        ConfirmDeleteSpending spendingId ->
             ( { model | showDialog = Nothing }
-            , Lamdera.sendToBackend (DeleteTransaction transactionId)
+            , Lamdera.sendToBackend (DeleteSpending spendingId)
             )
 
         SetToday today ->
             case model.showDialog of
                 Just (AddSpendingDialog dialogModel) ->
+                    let
+                        spendingDate =
+                            dialogModel.date |> Maybe.withDefault today
+
+                        applyDefault =
+                            applySpendingDateDefault dialogModel.date spendingDate
+
+                        setTodayInLine line =
+                            { line | datePickerModel = DatePicker.setToday today line.datePickerModel }
+                    in
                     ( { model
                         | showDialog =
                             Just
                                 (AddSpendingDialog
-                                    { dialogModel
-                                        | datePickerModel = DatePicker.setToday today dialogModel.datePickerModel
-                                    }
+                                    (normalizeSpendingDialogLines
+                                        { dialogModel
+                                            | datePickerModel = DatePicker.setToday today dialogModel.datePickerModel
+                                            , date = Just spendingDate
+                                            , dateText =
+                                                if dialogModel.dateText == "" then
+                                                    Date.toIsoString spendingDate
+
+                                                else
+                                                    dialogModel.dateText
+                                            , credits =
+                                                dialogModel.credits
+                                                    |> List.map setTodayInLine
+                                                    |> applyDefault
+                                            , debits =
+                                                dialogModel.debits
+                                                    |> List.map setTodayInLine
+                                                    |> applyDefault
+                                        }
+                                    )
                                 )
                       }
                     , Cmd.none
@@ -284,76 +311,43 @@ update msg model =
 
                         Just (AddSpendingDialog dialogModel) ->
                             let
-                                credits =
-                                    dialogModel.credits
-                                        |> List.map
-                                            (\( group, amount, _ ) ->
-                                                ( group
-                                                , amount
-                                                    |> parseAmountValue
-                                                    |> Maybe.withDefault 0
-                                                )
-                                            )
-                                        |> Dict.fromListDedupe (+)
-                                        |> Dict.map (\_ -> Amount)
+                                maybeTotal =
+                                    dialogModel.total |> parseAmountValue
 
-                                debits =
-                                    dialogModel.debits
-                                        |> List.map
-                                            (\( group, amount, _ ) ->
-                                                ( group
-                                                , amount
-                                                    |> parseAmountValue
-                                                    |> Maybe.withDefault 0
-                                                )
-                                            )
-                                        |> Dict.fromListDedupe (+)
-                                        |> Dict.map (\_ -> Amount)
+                                transactions =
+                                    dialogTransactions dialogModel
                             in
-                            case
-                                ( dialogModel.date
-                                , parseAmountValue dialogModel.total
+                            if List.isEmpty transactions || Maybe.isNothing maybeTotal then
+                                ( model, Cmd.none )
+
+                            else
+                                ( { model
+                                    | showDialog =
+                                        Just
+                                            (AddSpendingDialog
+                                                { dialogModel | submitted = True }
+                                            )
+                                  }
+                                , case dialogModel.spendingId of
+                                    Nothing ->
+                                        Lamdera.sendToBackend
+                                            (CreateSpending
+                                                { description = dialogModel.description
+                                                , total = maybeTotal |> Maybe.withDefault 0 |> Amount
+                                                , transactions = transactions
+                                                }
+                                            )
+
+                                    Just spendingId ->
+                                        Lamdera.sendToBackend
+                                            (EditSpending
+                                                { spendingId = spendingId
+                                                , description = dialogModel.description
+                                                , total = maybeTotal |> Maybe.withDefault 0 |> Amount
+                                                , transactions = transactions
+                                                }
+                                            )
                                 )
-                            of
-                                ( Just date, Just total ) ->
-                                    ( { model
-                                        | showDialog =
-                                            Just
-                                                (AddSpendingDialog
-                                                    { dialogModel | submitted = True }
-                                                )
-                                      }
-                                    , case dialogModel.transactionId of
-                                        Nothing ->
-                                            Lamdera.sendToBackend
-                                                (CreateSpending
-                                                    { description = dialogModel.description
-                                                    , year = Date.year date
-                                                    , month = Date.monthNumber date
-                                                    , day = Date.day date
-                                                    , total = Amount total
-                                                    , credits = credits
-                                                    , debits = debits
-                                                    }
-                                                )
-
-                                        Just transactionId ->
-                                            Lamdera.sendToBackend
-                                                (EditTransaction
-                                                    { transactionId = transactionId
-                                                    , description = dialogModel.description
-                                                    , year = Date.year date
-                                                    , month = Date.monthNumber date
-                                                    , day = Date.day date
-                                                    , total = Amount total
-                                                    , credits = credits
-                                                    , debits = debits
-                                                    }
-                                                )
-                                    )
-
-                                _ ->
-                                    ( model, Cmd.none )
 
                         Just (ConfirmDeleteDialog _) ->
                             -- This should not happen as ConfirmDeleteDialog has its own buttons
@@ -510,41 +504,49 @@ update msg model =
                 _ ->
                     ( model, Cmd.none )
 
-        UpdateTotal total ->
-            case model.showDialog of
-                Just (AddSpendingDialog dialogModel) ->
-                    ( { model | showDialog = Just (AddSpendingDialog { dialogModel | total = total }) }
-                    , Cmd.none
-                    )
-
-                _ ->
-                    ( model, Cmd.none )
-
-        ChangeDatePicker changeEvent ->
+        UpdateSpendingTotal total ->
             case model.showDialog of
                 Just (AddSpendingDialog dialogModel) ->
                     ( { model
                         | showDialog =
                             Just
                                 (AddSpendingDialog
-                                    (case changeEvent of
-                                        DatePicker.DateChanged date ->
-                                            { dialogModel
-                                                | date = Just date
-                                                , dateText = Date.toIsoString date
-                                                , datePickerModel = DatePicker.close dialogModel.datePickerModel
-                                            }
+                                    (normalizeSpendingDialogLines { dialogModel | total = total })
+                                )
+                      }
+                    , Cmd.none
+                    )
 
-                                        DatePicker.TextChanged dateText ->
-                                            { dialogModel
-                                                | date =
-                                                    Date.fromIsoString dateText
-                                                        |> Result.toMaybe
-                                                , dateText = dateText
-                                            }
+                _ ->
+                    ( model, Cmd.none )
 
-                                        DatePicker.PickerChanged subMsg ->
-                                            { dialogModel | datePickerModel = DatePicker.update subMsg dialogModel.datePickerModel }
+        UpdateSpendingDate changeEvent ->
+            case model.showDialog of
+                Just (AddSpendingDialog dialogModel) ->
+                    ( { model
+                        | showDialog =
+                            Just
+                                (AddSpendingDialog
+                                    (updateSpendingDate changeEvent dialogModel)
+                                )
+                      }
+                    , Cmd.none
+                    )
+
+                _ ->
+                    ( model, Cmd.none )
+
+        AddCredit ->
+            case model.showDialog of
+                Just (AddSpendingDialog dialogModel) ->
+                    ( { model
+                        | showDialog =
+                            Just
+                                (AddSpendingDialog
+                                    (normalizeSpendingDialogLines
+                                        { dialogModel
+                                            | credits = addTransactionLine dialogModel.date dialogModel.total dialogModel.credits
+                                        }
                                     )
                                 )
                       }
@@ -554,41 +556,21 @@ update msg model =
                 _ ->
                     ( model, Cmd.none )
 
-        AddCreditor group ->
+        UpdateCreditGroup index group ->
             case model.showDialog of
                 Just (AddSpendingDialog dialogModel) ->
                     ( { model
                         | showDialog =
                             Just
                                 (AddSpendingDialog
-                                    { dialogModel
-                                        | credits =
-                                            dialogModel.credits
-                                                |> addGroup dialogModel group
-                                    }
-                                )
-                      }
-                    , Lamdera.sendToBackend (AutocompleteGroup group)
-                    )
-
-                _ ->
-                    ( model, Cmd.none )
-
-        UpdateCreditor index group ->
-            case model.showDialog of
-                Just (AddSpendingDialog dialogModel) ->
-                    ( { model
-                        | showDialog =
-                            Just
-                                (AddSpendingDialog
-                                    { dialogModel
-                                        | credits =
-                                            dialogModel.credits
-                                                |> updateNameInList
-                                                    index
-                                                    group
-                                                    (computeRemainder dialogModel)
-                                    }
+                                    (normalizeSpendingDialogLines
+                                        { dialogModel
+                                            | credits =
+                                                updateTransactionLine index
+                                                    (\line -> { line | group = group, nameValidity = Incomplete })
+                                                    dialogModel.credits
+                                        }
+                                    )
                                 )
                       }
                     , if String.length group > 0 then
@@ -601,18 +583,21 @@ update msg model =
                 _ ->
                     ( model, Cmd.none )
 
-        UpdateCredit index amount ->
+        UpdateCreditAmount index amount ->
             case model.showDialog of
                 Just (AddSpendingDialog dialogModel) ->
                     ( { model
                         | showDialog =
                             Just
                                 (AddSpendingDialog
-                                    { dialogModel
-                                        | credits =
-                                            dialogModel.credits
-                                                |> updateValueInList index amount
-                                    }
+                                    (normalizeSpendingDialogLines
+                                        { dialogModel
+                                            | credits =
+                                                updateTransactionLine index
+                                                    (\line -> { line | amount = amount })
+                                                    dialogModel.credits
+                                        }
+                                    )
                                 )
                       }
                     , Cmd.none
@@ -621,41 +606,127 @@ update msg model =
                 _ ->
                     ( model, Cmd.none )
 
-        AddDebitor group ->
+        RemoveCredit index ->
             case model.showDialog of
                 Just (AddSpendingDialog dialogModel) ->
                     ( { model
                         | showDialog =
                             Just
                                 (AddSpendingDialog
-                                    { dialogModel
-                                        | debits =
-                                            dialogModel.debits
-                                                |> addGroup dialogModel group
-                                    }
+                                    (normalizeSpendingDialogLines
+                                        { dialogModel
+                                            | credits = removeTransactionLine index dialogModel.credits
+                                        }
+                                    )
                                 )
                       }
-                    , Lamdera.sendToBackend (AutocompleteGroup group)
+                    , Cmd.none
                     )
 
                 _ ->
                     ( model, Cmd.none )
 
-        UpdateDebitor index group ->
+        ToggleCreditDetails index ->
             case model.showDialog of
                 Just (AddSpendingDialog dialogModel) ->
                     ( { model
                         | showDialog =
                             Just
                                 (AddSpendingDialog
-                                    { dialogModel
-                                        | debits =
-                                            dialogModel.debits
-                                                |> updateNameInList
-                                                    index
-                                                    group
-                                                    (computeRemainder dialogModel)
-                                    }
+                                    (normalizeSpendingDialogLines
+                                        { dialogModel
+                                            | credits =
+                                                updateTransactionLine index
+                                                    (\line -> { line | detailsExpanded = not line.detailsExpanded })
+                                                    dialogModel.credits
+                                        }
+                                    )
+                                )
+                      }
+                    , Cmd.none
+                    )
+
+                _ ->
+                    ( model, Cmd.none )
+
+        UpdateCreditDate index changeEvent ->
+            case model.showDialog of
+                Just (AddSpendingDialog dialogModel) ->
+                    ( { model
+                        | showDialog =
+                            Just
+                                (AddSpendingDialog
+                                    (normalizeSpendingDialogLines
+                                        { dialogModel
+                                            | credits = updateTransactionLineDate index changeEvent dialogModel.credits
+                                        }
+                                    )
+                                )
+                      }
+                    , Cmd.none
+                    )
+
+                _ ->
+                    ( model, Cmd.none )
+
+        UpdateCreditSecondaryDescription index description ->
+            case model.showDialog of
+                Just (AddSpendingDialog dialogModel) ->
+                    ( { model
+                        | showDialog =
+                            Just
+                                (AddSpendingDialog
+                                    (normalizeSpendingDialogLines
+                                        { dialogModel
+                                            | credits =
+                                                updateTransactionLine index
+                                                    (\line -> { line | secondaryDescription = description })
+                                                    dialogModel.credits
+                                        }
+                                    )
+                                )
+                      }
+                    , Cmd.none
+                    )
+
+                _ ->
+                    ( model, Cmd.none )
+
+        AddDebit ->
+            case model.showDialog of
+                Just (AddSpendingDialog dialogModel) ->
+                    ( { model
+                        | showDialog =
+                            Just
+                                (AddSpendingDialog
+                                    (normalizeSpendingDialogLines
+                                        { dialogModel
+                                            | debits = addTransactionLine dialogModel.date dialogModel.total dialogModel.debits
+                                        }
+                                    )
+                                )
+                      }
+                    , Cmd.none
+                    )
+
+                _ ->
+                    ( model, Cmd.none )
+
+        UpdateDebitGroup index group ->
+            case model.showDialog of
+                Just (AddSpendingDialog dialogModel) ->
+                    ( { model
+                        | showDialog =
+                            Just
+                                (AddSpendingDialog
+                                    (normalizeSpendingDialogLines
+                                        { dialogModel
+                                            | debits =
+                                                updateTransactionLine index
+                                                    (\line -> { line | group = group, nameValidity = Incomplete })
+                                                    dialogModel.debits
+                                        }
+                                    )
                                 )
                       }
                     , if String.length group > 0 then
@@ -668,18 +739,107 @@ update msg model =
                 _ ->
                     ( model, Cmd.none )
 
-        UpdateDebit index amount ->
+        UpdateDebitAmount index amount ->
             case model.showDialog of
                 Just (AddSpendingDialog dialogModel) ->
                     ( { model
                         | showDialog =
                             Just
                                 (AddSpendingDialog
-                                    { dialogModel
-                                        | debits =
-                                            dialogModel.debits
-                                                |> updateValueInList index amount
-                                    }
+                                    (normalizeSpendingDialogLines
+                                        { dialogModel
+                                            | debits =
+                                                updateTransactionLine index
+                                                    (\line -> { line | amount = amount })
+                                                    dialogModel.debits
+                                        }
+                                    )
+                                )
+                      }
+                    , Cmd.none
+                    )
+
+                _ ->
+                    ( model, Cmd.none )
+
+        UpdateDebitDate index changeEvent ->
+            case model.showDialog of
+                Just (AddSpendingDialog dialogModel) ->
+                    ( { model
+                        | showDialog =
+                            Just
+                                (AddSpendingDialog
+                                    (normalizeSpendingDialogLines
+                                        { dialogModel
+                                            | debits = updateTransactionLineDate index changeEvent dialogModel.debits
+                                        }
+                                    )
+                                )
+                      }
+                    , Cmd.none
+                    )
+
+                _ ->
+                    ( model, Cmd.none )
+
+        UpdateDebitSecondaryDescription index description ->
+            case model.showDialog of
+                Just (AddSpendingDialog dialogModel) ->
+                    ( { model
+                        | showDialog =
+                            Just
+                                (AddSpendingDialog
+                                    (normalizeSpendingDialogLines
+                                        { dialogModel
+                                            | debits =
+                                                updateTransactionLine index
+                                                    (\line -> { line | secondaryDescription = description })
+                                                    dialogModel.debits
+                                        }
+                                    )
+                                )
+                      }
+                    , Cmd.none
+                    )
+
+                _ ->
+                    ( model, Cmd.none )
+
+        RemoveDebit index ->
+            case model.showDialog of
+                Just (AddSpendingDialog dialogModel) ->
+                    ( { model
+                        | showDialog =
+                            Just
+                                (AddSpendingDialog
+                                    (normalizeSpendingDialogLines
+                                        { dialogModel
+                                            | debits = removeTransactionLine index dialogModel.debits
+                                        }
+                                    )
+                                )
+                      }
+                    , Cmd.none
+                    )
+
+                _ ->
+                    ( model, Cmd.none )
+
+        ToggleDebitDetails index ->
+            case model.showDialog of
+                Just (AddSpendingDialog dialogModel) ->
+                    ( { model
+                        | showDialog =
+                            Just
+                                (AddSpendingDialog
+                                    (normalizeSpendingDialogLines
+                                        { dialogModel
+                                            | debits =
+                                                updateTransactionLine index
+                                                    (\line -> { line | detailsExpanded = not line.detailsExpanded })
+                                                    dialogModel.debits
+                                        }
+                                    )
                                 )
                       }
                     , Cmd.none
@@ -736,21 +896,268 @@ update msg model =
             )
 
 
-computeRemainder { total } list =
+emptySpendingDialog spendingId description total =
+    normalizeSpendingDialogLines
+        { spendingId = spendingId
+        , description = description
+        , total = total
+        , date = Nothing
+        , dateText = ""
+        , datePickerModel = DatePicker.init
+        , credits = []
+        , debits = []
+        , submitted = False
+        }
+
+
+setSpendingDateValue date dialogModel =
+    { dialogModel
+        | date = Just date
+        , dateText = Date.toIsoString date
+        , datePickerModel = DatePicker.initWithToday date
+    }
+
+
+defaultTransactionLine maybeDate amount =
+    { date = maybeDate
+    , dateText = maybeDate |> Maybe.map Date.toIsoString |> Maybe.withDefault ""
+    , datePickerModel =
+        maybeDate
+            |> Maybe.map DatePicker.initWithToday
+            |> Maybe.withDefault DatePicker.init
+    , secondaryDescription = ""
+    , detailsExpanded = False
+    , group = ""
+    , amount = amount
+    , nameValidity = Incomplete
+    }
+
+
+remainingAmount total lines =
     ((total
         |> parseAmountValue
         |> Maybe.withDefault 0
      )
-        - (list
-            |> List.filterMap (\( _, amount, _ ) -> amount |> parseAmountValue)
+        - (lines
+            |> List.filterMap (.amount >> parseAmountValue)
             |> List.sum
           )
     )
-        |> viewAmount
+        |> formatAmountValue
 
 
-addGroup model name list =
-    addNameInList name (computeRemainder model list) list
+addTransactionLine maybeDate total lines =
+    lines ++ [ defaultTransactionLine maybeDate (defaultTransactionLineAmount total lines) ]
+
+
+removeTransactionLine index lines =
+    lines
+        |> List.indexedMap Tuple.pair
+        |> List.filter (\( currentIndex, _ ) -> currentIndex /= index)
+        |> List.map Tuple.second
+
+
+updateTransactionLine index updateLine lines =
+    List.updateAt index updateLine lines
+
+
+updateTransactionLineDate index changeEvent lines =
+    updateTransactionLine index
+        (\line ->
+            case changeEvent of
+                DatePicker.DateChanged date ->
+                    { line
+                        | date = Just date
+                        , dateText = Date.toIsoString date
+                        , datePickerModel = DatePicker.close line.datePickerModel
+                    }
+
+                DatePicker.TextChanged dateText ->
+                    { line
+                        | date = Date.fromIsoString dateText |> Result.toMaybe
+                        , dateText = dateText
+                    }
+
+                DatePicker.PickerChanged subMsg ->
+                    { line | datePickerModel = DatePicker.update subMsg line.datePickerModel }
+        )
+        lines
+
+
+defaultTransactionLineAmount total lines =
+    if String.trim total == "" then
+        ""
+
+    else
+        remainingAmount total lines
+
+
+transactionLineIsComplete line =
+    String.trim line.group
+        /= ""
+        && (line.amount |> parseAmountValue |> Maybe.isJust)
+        && Maybe.isJust line.date
+
+
+transactionLineIsBlank spendingDate line =
+    String.trim line.group
+        == ""
+        && String.trim line.amount
+        == ""
+        && not (transactionLineHasCustomDetails spendingDate line)
+
+
+normalizeTransactionLines maybeDate total lines =
+    let
+        nonBlankLines =
+            lines
+                |> List.filter (transactionLineIsBlank maybeDate >> not)
+    in
+    if List.last nonBlankLines |> Maybe.map transactionLineIsComplete |> Maybe.withDefault True then
+        nonBlankLines ++ [ defaultTransactionLine maybeDate (defaultTransactionLineAmount total nonBlankLines) ]
+
+    else
+        nonBlankLines
+
+
+normalizeTransactionLinesWithoutAutofill maybeDate lines =
+    let
+        nonBlankLines =
+            lines
+                |> List.filter (transactionLineIsBlank maybeDate >> not)
+    in
+    if List.last nonBlankLines |> Maybe.map transactionLineIsComplete |> Maybe.withDefault True then
+        nonBlankLines ++ [ defaultTransactionLine maybeDate "" ]
+
+    else
+        nonBlankLines
+
+
+normalizeSpendingDialogLines dialogModel =
+    { dialogModel
+        | credits = normalizeTransactionLinesWithoutAutofill dialogModel.date dialogModel.credits
+        , debits = normalizeTransactionLinesWithoutAutofill dialogModel.date dialogModel.debits
+    }
+
+
+lineUsesDefaultDate previousSpendingDate line =
+    case ( previousSpendingDate, line.date ) of
+        ( _, Nothing ) ->
+            True
+
+        ( Just previousDate, Just lineDate ) ->
+            lineDate == previousDate
+
+        ( Nothing, Just _ ) ->
+            False
+
+
+setTransactionLineDate date line =
+    { line
+        | date = Just date
+        , dateText = Date.toIsoString date
+        , datePickerModel = DatePicker.initWithToday date
+    }
+
+
+applySpendingDateDefault previousSpendingDate newDate =
+    List.map
+        (\line ->
+            if lineUsesDefaultDate previousSpendingDate line then
+                setTransactionLineDate newDate line
+
+            else
+                line
+        )
+
+
+updateSpendingDate changeEvent dialogModel =
+    case changeEvent of
+        DatePicker.DateChanged date ->
+            let
+                applyDefault =
+                    applySpendingDateDefault dialogModel.date date
+
+                updatedDialog =
+                    dialogModel |> setSpendingDateValue date
+            in
+            normalizeSpendingDialogLines
+                { updatedDialog
+                    | credits = applyDefault dialogModel.credits
+                    , debits = applyDefault dialogModel.debits
+                }
+
+        DatePicker.TextChanged dateText ->
+            case Date.fromIsoString dateText |> Result.toMaybe of
+                Just date ->
+                    let
+                        applyDefault =
+                            applySpendingDateDefault dialogModel.date date
+
+                        updatedDialog =
+                            dialogModel |> setSpendingDateValue date
+                    in
+                    normalizeSpendingDialogLines
+                        { updatedDialog
+                            | dateText = dateText
+                            , credits = applyDefault dialogModel.credits
+                            , debits = applyDefault dialogModel.debits
+                        }
+
+                Nothing ->
+                    { dialogModel | date = Nothing, dateText = dateText }
+
+        DatePicker.PickerChanged subMsg ->
+            { dialogModel | datePickerModel = DatePicker.update subMsg dialogModel.datePickerModel }
+
+
+transactionLineFromSpendingTransaction side transaction =
+    if transaction.side == side then
+        case transaction.amount of
+            Amount amount ->
+                let
+                    date =
+                        Date.fromCalendarDate transaction.year (Date.numberToMonth transaction.month) transaction.day
+                in
+                Just
+                    { date = Just date
+                    , dateText = Date.toIsoString date
+                    , datePickerModel = DatePicker.initWithToday date
+                    , secondaryDescription = transaction.secondaryDescription
+                    , detailsExpanded = False
+                    , group = transaction.group
+                    , amount = formatAmountValue amount
+                    , nameValidity = Complete
+                    }
+
+    else
+        Nothing
+
+
+transactionLineToSpendingTransaction side line =
+    case ( line.date, parseAmountValue line.amount ) of
+        ( Just date, Just amount ) ->
+            Just
+                { year = Date.year date
+                , month = Date.monthNumber date
+                , day = Date.day date
+                , secondaryDescription = line.secondaryDescription
+                , group = line.group
+                , amount = Amount amount
+                , side = side
+                }
+
+        _ ->
+            Nothing
+
+
+dialogTransactions dialogModel =
+    (dialogModel.debits
+        |> List.filterMap (transactionLineToSpendingTransaction DebitTransaction)
+    )
+        ++ (dialogModel.credits
+                |> List.filterMap (transactionLineToSpendingTransaction CreditTransaction)
+           )
 
 
 addNameInList name defaultValue list =
@@ -966,12 +1373,8 @@ updateFromBackend msg model =
                             Just
                                 (AddSpendingDialog
                                     { dialogModel
-                                        | credits =
-                                            dialogModel.credits
-                                                |> markInvalidPrefix prefix
-                                        , debits =
-                                            dialogModel.debits
-                                                |> markInvalidPrefix prefix
+                                        | credits = dialogModel.credits |> markInvalidGroupPrefix prefix
+                                        , debits = dialogModel.debits |> markInvalidGroupPrefix prefix
                                     }
                                 )
                       }
@@ -998,12 +1401,8 @@ updateFromBackend msg model =
                             Just
                                 (AddSpendingDialog
                                     { dialogModel
-                                        | credits =
-                                            dialogModel.credits
-                                                |> completeToLongestCommonPrefix response
-                                        , debits =
-                                            dialogModel.debits
-                                                |> completeToLongestCommonPrefix response
+                                        | credits = dialogModel.credits |> completeGroupPrefix response
+                                        , debits = dialogModel.debits |> completeGroupPrefix response
                                     }
                                 )
                       }
@@ -1088,31 +1487,73 @@ updateFromBackend msg model =
                 _ ->
                     ( model, Cmd.none )
 
-        TransactionError errorMessage ->
-            -- For now, do nothing
+        SpendingError _ ->
             -- TODO: Show error message to user in UI
-            ( model, Cmd.none )
+            case model.showDialog of
+                Just (AddSpendingDialog dialogModel) ->
+                    ( { model
+                        | showDialog =
+                            Just (AddSpendingDialog { dialogModel | submitted = False })
+                      }
+                    , Cmd.none
+                    )
 
-        TransactionDetails { transactionId, description, year, month, day, total, credits, debits } ->
+                _ ->
+                    ( model, Cmd.none )
+
+        SpendingDetails { spendingId, description, total, transactions } ->
             -- Update the edit dialog with the fetched transaction details
             case model.showDialog of
                 Just (AddSpendingDialog dialogModel) ->
-                    if dialogModel.transactionId == Just transactionId then
+                    if dialogModel.spendingId == Just spendingId then
                         let
-                            creditsList =
-                                Dict.toList credits |> List.map (\( group, Amount amount ) -> ( group, formatAmountValue amount, Complete ))
+                            spendingDate =
+                                transactions
+                                    |> List.sortBy (\transaction -> ( transaction.year, transaction.month, transaction.day ))
+                                    |> List.head
+                                    |> Maybe.map
+                                        (\transaction ->
+                                            Date.fromCalendarDate
+                                                transaction.year
+                                                (Date.numberToMonth transaction.month)
+                                                transaction.day
+                                        )
 
-                            debitsList =
-                                Dict.toList debits |> List.map (\( group, Amount amount ) -> ( group, formatAmountValue amount, Complete ))
+                            credits =
+                                transactions
+                                    |> List.filterMap (transactionLineFromSpendingTransaction CreditTransaction)
+
+                            debits =
+                                transactions
+                                    |> List.filterMap (transactionLineFromSpendingTransaction DebitTransaction)
                         in
                         ( { model
                             | showDialog =
                                 Just
                                     (AddSpendingDialog
-                                        { dialogModel
-                                            | credits = creditsList
-                                            , debits = debitsList
-                                        }
+                                        (normalizeSpendingDialogLines
+                                            { dialogModel
+                                                | description = description
+                                                , total = total |> (\(Amount amount) -> formatAmountValue amount)
+                                                , date =
+                                                    case spendingDate of
+                                                        Just spendingDateValue ->
+                                                            Just spendingDateValue
+
+                                                        Nothing ->
+                                                            dialogModel.date
+                                                , dateText =
+                                                    spendingDate
+                                                        |> Maybe.map Date.toIsoString
+                                                        |> Maybe.withDefault dialogModel.dateText
+                                                , datePickerModel =
+                                                    spendingDate
+                                                        |> Maybe.map DatePicker.initWithToday
+                                                        |> Maybe.withDefault dialogModel.datePickerModel
+                                                , credits = credits
+                                                , debits = debits
+                                            }
+                                        )
                                     )
                           }
                         , Cmd.none
@@ -1160,6 +1601,45 @@ completeToLongestCommonPrefix { prefixLower, longestCommonPrefix, complete } lis
 
                 else
                     ( name, value, nameValidity )
+            )
+
+
+markInvalidGroupPrefix prefix lines =
+    lines
+        |> List.map
+            (\line ->
+                if String.startsWith prefix line.group then
+                    { line | nameValidity = InvalidPrefix }
+
+                else
+                    line
+            )
+
+
+completeGroupPrefix { prefixLower, longestCommonPrefix, complete } lines =
+    lines
+        |> List.map
+            (\line ->
+                let
+                    groupLower =
+                        String.toLower line.group
+                in
+                if
+                    String.startsWith prefixLower groupLower
+                        && String.startsWith groupLower (String.toLower longestCommonPrefix)
+                then
+                    { line
+                        | group = longestCommonPrefix
+                        , nameValidity =
+                            if complete then
+                                Complete
+
+                            else
+                                Incomplete
+                    }
+
+                else
+                    line
             )
 
 
@@ -1371,18 +1851,18 @@ view model =
                                         AddSpendingDialog dialogModel ->
                                             let
                                                 title =
-                                                    case dialogModel.transactionId of
+                                                    case dialogModel.spendingId of
                                                         Nothing ->
-                                                            "Add Transaction"
+                                                            "Add Spending"
 
                                                         Just _ ->
-                                                            "Edit Transaction"
+                                                            "Edit Spending"
                                             in
                                             config title
                                                 (addSpendingInputs palette model.windowWidth dialogModel)
                                                 (canSubmitSpending dialogModel)
 
-                                        ConfirmDeleteDialog transactionId ->
+                                        ConfirmDeleteDialog spendingId ->
                                             { closeMessage = Just Cancel
                                             , maskAttributes = []
                                             , containerAttributes =
@@ -1414,7 +1894,7 @@ view model =
                                                 Just
                                                     (column [ spacing 15 ]
                                                         [ Element.paragraph []
-                                                            [ Element.text "Are you sure you want to delete this transaction?" ]
+                                                            [ Element.text "Are you sure you want to delete this spending?" ]
                                                         ]
                                                     )
                                             , footer =
@@ -1426,7 +1906,7 @@ view model =
                                                             }
                                                         , Input.button (greenButtonStyle palette)
                                                             { label = text "Delete"
-                                                            , onPress = Just (ConfirmDeleteTransaction transactionId)
+                                                            , onPress = Just (ConfirmDeleteSpending spendingId)
                                                             }
                                                         ]
                                                     )
@@ -1579,6 +2059,26 @@ grayButtonStyle palette =
     buttonStyle ++ [ Background.color palette.disabledButton, Font.color palette.text ]
 
 
+iconButtonStyle palette =
+    [ Background.color palette.disabledButton
+    , Font.color palette.text
+    , Border.color palette.border
+    , Border.width 1
+    , padding 7
+    , Border.rounded 999
+    ]
+
+
+deleteIconButtonStyle palette =
+    [ Background.color palette.deleteButton
+    , Font.color palette.text
+    , Border.color palette.border
+    , Border.width 1
+    , padding 7
+    , Border.rounded 999
+    ]
+
+
 type alias Palette =
     { background : Color
     , surface : Color
@@ -1685,7 +2185,7 @@ addGroupInputs palette windowWidth ({ members } as model) =
             members
 
 
-addSpendingInputs palette windowWidth { description, date, dateText, datePickerModel, total, credits, debits } =
+addSpendingInputs palette windowWidth { description, total, date, dateText, datePickerModel, credits, debits } =
     [ Input.text (inputStyle palette)
         { label = labelStyle windowWidth "Description"
         , placeholder = Nothing
@@ -1695,7 +2195,7 @@ addSpendingInputs palette windowWidth { description, date, dateText, datePickerM
     , DatePicker.input (inputStyle palette)
         { label = labelStyle windowWidth "Date"
         , placeholder = Nothing
-        , onChange = ChangeDatePicker
+        , onChange = UpdateSpendingDate
         , selected = date
         , text = dateText
         , settings = DatePicker.defaultSettings
@@ -1704,34 +2204,207 @@ addSpendingInputs palette windowWidth { description, date, dateText, datePickerM
     , Input.text (inputStyle palette)
         { label = labelStyle windowWidth "Total"
         , placeholder = Nothing
-        , onChange = UpdateTotal
+        , onChange = UpdateSpendingTotal
         , text = total
         }
-    , column [ spacing 20, Background.color palette.surface, padding 20 ]
-        ([ text "Debitors" ]
-            ++ listInputs
-                palette
-                windowWidth
-                "Debitor"
-                "Amount"
-                AddDebitor
-                UpdateDebitor
-                UpdateDebit
-                debits
-        )
-    , column [ spacing 20, Background.color palette.surface, padding 20 ]
-        ([ text "Creditors (payers)" ]
-            ++ listInputs
-                palette
-                windowWidth
-                "Creditor"
-                "Amount"
-                AddCreditor
-                UpdateCreditor
-                UpdateCredit
-                credits
-        )
+    , transactionLineInputs
+        palette
+        windowWidth
+        date
+        "Debitors"
+        "Debitor"
+        AddDebit
+        RemoveDebit
+        ToggleDebitDetails
+        UpdateDebitDate
+        UpdateDebitSecondaryDescription
+        UpdateDebitGroup
+        UpdateDebitAmount
+        debits
+    , transactionLineInputs
+        palette
+        windowWidth
+        date
+        "Creditors (payers)"
+        "Creditor"
+        AddCredit
+        RemoveCredit
+        ToggleCreditDetails
+        UpdateCreditDate
+        UpdateCreditSecondaryDescription
+        UpdateCreditGroup
+        UpdateCreditAmount
+        credits
     ]
+
+
+transactionLineInputs palette windowWidth spendingDate title lineLabel addMsg removeMsg toggleDetailsMsg updateDateMsg updateSecondaryDescriptionMsg updateGroupMsg updateAmountMsg lines =
+    column [ spacing 15, Background.color palette.surface, padding 20, width fill ]
+        ([ row [ spacing 10, width fill ]
+            [ text title ]
+         ]
+            ++ (lines
+                    |> List.indexedMap
+                        (\index line ->
+                            let
+                                attributes =
+                                    case line.nameValidity of
+                                        InvalidPrefix ->
+                                            inputStyle palette ++ [ Background.color palette.error ]
+
+                                        _ ->
+                                            inputStyle palette
+
+                                detailsVisible =
+                                    transactionLineDetailsVisible spendingDate line
+
+                                showRemoveButton =
+                                    List.length lines > 1 || not (transactionLineIsBlank spendingDate line)
+                            in
+                            column
+                                [ spacing 12
+                                , Background.color palette.background
+                                , padding 15
+                                , width fill
+                                , Border.rounded 5
+                                ]
+                                ([ row [ spacing 10, width fill ]
+                                    ([ el [ width fill ] none
+                                     , transactionLineDetailsToggle palette spendingDate line (toggleDetailsMsg index)
+                                     ]
+                                        ++ (if showRemoveButton then
+                                                [ Input.button
+                                                    (deleteIconButtonStyle palette)
+                                                    { label = removeIcon
+                                                    , onPress = Just (removeMsg index)
+                                                    }
+                                                ]
+
+                                            else
+                                                []
+                                           )
+                                    )
+                                 , wrappedRow [ spacing 15, width fill ]
+                                    [ el [ width (transactionLineFlexibleFieldWidth windowWidth) ]
+                                        (Input.text (attributes ++ [ width fill ])
+                                            { label = labelStyle windowWidth (lineLabel ++ " " ++ String.fromInt (index + 1))
+                                            , placeholder = Nothing
+                                            , onChange = updateGroupMsg index
+                                            , text = line.group
+                                            }
+                                        )
+                                    , el [ width (transactionLineCompactFieldWidth windowWidth) ]
+                                        (Input.text (inputStyle palette ++ [ width fill ])
+                                            { label = labelStyle windowWidth "Amount"
+                                            , placeholder = Nothing
+                                            , onChange = updateAmountMsg index
+                                            , text = line.amount
+                                            }
+                                        )
+                                    ]
+                                 ]
+                                    ++ (if detailsVisible then
+                                            [ wrappedRow [ spacing 15, width fill ]
+                                                [ el [ width (transactionLineFlexibleFieldWidth windowWidth) ]
+                                                    (Input.text (inputStyle palette ++ [ width fill ])
+                                                        { label = labelStyle windowWidth "Description"
+                                                        , placeholder = Nothing
+                                                        , onChange = updateSecondaryDescriptionMsg index
+                                                        , text = line.secondaryDescription
+                                                        }
+                                                    )
+                                                , el [ width (transactionLineCompactFieldWidth windowWidth) ]
+                                                    (DatePicker.input (inputStyle palette ++ [ width fill ])
+                                                        { label = labelStyle windowWidth "Date"
+                                                        , placeholder = Nothing
+                                                        , onChange = updateDateMsg index
+                                                        , selected = line.date
+                                                        , text = line.dateText
+                                                        , settings = DatePicker.defaultSettings
+                                                        , model = line.datePickerModel
+                                                        }
+                                                    )
+                                                ]
+                                            ]
+
+                                        else
+                                            []
+                                       )
+                                )
+                        )
+               )
+        )
+
+
+transactionLineHasCustomDetails spendingDate line =
+    String.trim line.secondaryDescription
+        /= ""
+        || not (lineUsesDefaultDate spendingDate line)
+
+
+transactionLineFlexibleFieldWidth windowWidth =
+    if windowWidth > 650 then
+        fill
+
+    else
+        fillPortion 1
+
+
+transactionLineCompactFieldWidth windowWidth =
+    if windowWidth > 650 then
+        px 150
+
+    else
+        fillPortion 1
+
+
+transactionLineDetailsVisible spendingDate line =
+    line.detailsExpanded || transactionLineHasCustomDetails spendingDate line
+
+
+transactionLineDetailsToggle palette spendingDate line toggleMsg =
+    if transactionLineHasCustomDetails spendingDate line then
+        el (iconButtonStyle palette) detailsExpandedIcon
+
+    else
+        Input.button
+            (iconButtonStyle palette)
+            { label =
+                if line.detailsExpanded then
+                    detailsExpandedIcon
+
+                else
+                    detailsCollapsedIcon
+            , onPress = Just toggleMsg
+            }
+
+
+detailsCollapsedIcon =
+    strokedIcon "M7 5l5 5-5 5"
+
+
+detailsExpandedIcon =
+    strokedIcon "M5 7l5 5 5-5"
+
+
+removeIcon =
+    strokedIcon "M6 6l8 8M14 6l-8 8"
+
+
+strokedIcon pathData =
+    html <|
+        Html.node "svg"
+            [ Attr.attribute "viewBox" "0 0 20 20"
+            , Attr.attribute "width" "16"
+            , Attr.attribute "height" "16"
+            , Attr.attribute "fill" "none"
+            , Attr.attribute "stroke" "currentColor"
+            , Attr.attribute "stroke-width" "1.75"
+            , Attr.attribute "stroke-linecap" "round"
+            , Attr.attribute "stroke-linejoin" "round"
+            , Attr.style "display" "block"
+            ]
+            [ Html.node "path" [ Attr.attribute "d" pathData ] [] ]
 
 
 listInputs palette windowWidth nameLabel valueLabel addMsg updateNameMsg updateValueMsg items =
@@ -1824,45 +2497,41 @@ canSubmitGroup { name, nameInvalid, members, submitted } =
            )
 
 
-canSubmitSpending { description, date, total, credits, debits, submitted } =
+validTransactionLines spendingDate lines =
+    let
+        meaningfulLines =
+            lines
+                |> List.filter (transactionLineIsBlank spendingDate >> not)
+    in
+    not (List.isEmpty meaningfulLines)
+        && (meaningfulLines
+                |> List.map
+                    (\line ->
+                        case ( line.date, parseAmountValue line.amount, line.nameValidity ) of
+                            ( Just _, Just _, Complete ) ->
+                                String.trim line.group /= ""
+
+                            _ ->
+                                False
+                    )
+                |> List.all identity
+           )
+
+
+canSubmitSpending { description, total, date, credits, debits, submitted } =
     not submitted
-        && Maybe.isJust date
         && String.length description
         > 0
+        && Maybe.isJust date
         && (total
                 |> parseAmountValue
-                |> Maybe.andThen
+                |> Maybe.map
                     (\totalInt ->
-                        Maybe.combine
-                            [ credits
-                                |> List.map
-                                    (\( _, amount, nameValidity ) ->
-                                        case nameValidity of
-                                            Complete ->
-                                                parseAmountValue amount
-
-                                            _ ->
-                                                Nothing
-                                    )
-                                |> Maybe.combine
-                                |> Maybe.map List.sum
-                                |> Maybe.map ((==) totalInt)
-                            , debits
-                                |> List.map
-                                    (\( _, amount, nameValidity ) ->
-                                        case nameValidity of
-                                            Complete ->
-                                                parseAmountValue amount
-
-                                            _ ->
-                                                Nothing
-                                    )
-                                |> Maybe.combine
-                                |> Maybe.map List.sum
-                                |> Maybe.map ((==) totalInt)
-                            ]
+                        totalInt
+                            > 0
+                            && validTransactionLines date credits
+                            && validTransactionLines date debits
                     )
-                |> Maybe.map (List.all identity)
                 |> Maybe.withDefault False
            )
 
@@ -1875,11 +2544,19 @@ viewTransaction palette transaction =
         , "(Total: " ++ (transaction.total |> (\(Amount amount) -> amount) |> viewAmount) ++ ")" |> text
         , row [ spacing 10 ]
             [ Input.button [ Background.color palette.editButton, padding 5, Border.rounded 3 ]
-                { onPress = Just (ShowAddSpendingDialog (Just transaction.transactionId))
+                { onPress =
+                    Just
+                        (ShowAddSpendingDialog
+                            (Just
+                                { spendingId = transaction.spendingId
+                                , transactionId = transaction.transactionId
+                                }
+                            )
+                        )
                 , label = text "Edit"
                 }
             , Input.button [ Background.color palette.deleteButton, padding 5, Border.rounded 3 ]
-                { onPress = Just (ShowConfirmDeleteDialog transaction.transactionId)
+                { onPress = Just (ShowConfirmDeleteDialog transaction.spendingId)
                 , label = text "Delete"
                 }
             ]

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -919,7 +919,10 @@ setSpendingDateValue date dialogModel =
 
 
 defaultTransactionLine maybeDate amount =
-    { date = maybeDate
+    { -- do NOT set the explicit .date here so that lines remain "unspecified"
+      -- until the user manually changes them. dateText still reflects the
+      -- dialog-level default for display.
+      date = Nothing
     , dateText = maybeDate |> Maybe.map Date.toIsoString |> Maybe.withDefault ""
     , datePickerModel =
         maybeDate
@@ -992,11 +995,13 @@ defaultTransactionLineAmount total lines =
         remainingAmount total lines
 
 
-transactionLineIsComplete line =
+transactionLineIsComplete maybeSpendingDate line =
     String.trim line.group
         /= ""
         && (line.amount |> parseAmountValue |> Maybe.isJust)
-        && Maybe.isJust line.date
+        -- a line is considered complete if it either has an explicit date or
+        -- the dialog has a spending-level date that can be used implicitly
+        && (Maybe.isJust line.date || Maybe.isJust maybeSpendingDate)
 
 
 transactionLineIsBlank spendingDate line =
@@ -1013,7 +1018,7 @@ normalizeTransactionLines maybeDate total lines =
             lines
                 |> List.filter (transactionLineIsBlank maybeDate >> not)
     in
-    if List.last nonBlankLines |> Maybe.map transactionLineIsComplete |> Maybe.withDefault True then
+    if List.last nonBlankLines |> Maybe.map (transactionLineIsComplete maybeDate) |> Maybe.withDefault True then
         nonBlankLines ++ [ defaultTransactionLine maybeDate (defaultTransactionLineAmount total nonBlankLines) ]
 
     else
@@ -1026,7 +1031,7 @@ normalizeTransactionLinesWithoutAutofill maybeDate lines =
             lines
                 |> List.filter (transactionLineIsBlank maybeDate >> not)
     in
-    if List.last nonBlankLines |> Maybe.map transactionLineIsComplete |> Maybe.withDefault True then
+    if List.last nonBlankLines |> Maybe.map (transactionLineIsComplete maybeDate) |> Maybe.withDefault True then
         nonBlankLines ++ [ defaultTransactionLine maybeDate "" ]
 
     else
@@ -1040,15 +1045,12 @@ normalizeSpendingDialogLines dialogModel =
     }
 
 
-lineUsesDefaultDate previousSpendingDate line =
-    case ( previousSpendingDate, line.date ) of
-        ( _, Nothing ) ->
+lineUsesDefaultDate _ line =
+    case line.date of
+        Nothing ->
             True
 
-        ( Just previousDate, Just lineDate ) ->
-            lineDate == previousDate
-
-        ( Nothing, Just _ ) ->
+        Just _ ->
             False
 
 
@@ -1063,11 +1065,19 @@ setTransactionLineDate date line =
 applySpendingDateDefault previousSpendingDate newDate =
     List.map
         (\line ->
-            if lineUsesDefaultDate previousSpendingDate line then
-                setTransactionLineDate newDate line
+            case line.date of
+                -- keep the explicit .date empty for lines that haven't been
+                -- manually adjusted; update only the displayed text and the
+                -- picker seed so the UI reflects the new default without
+                -- mutating the explicit value.
+                Nothing ->
+                    { line
+                        | dateText = Date.toIsoString newDate
+                        , datePickerModel = DatePicker.initWithToday newDate
+                    }
 
-            else
-                line
+                Just _ ->
+                    line
         )
 
 

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -1,5 +1,6 @@
 module Types exposing (..)
 
+import Array exposing (Array)
 import Basics.Extra exposing (flip)
 import Browser exposing (UrlRequest)
 import Browser.Navigation exposing (Key)
@@ -26,6 +27,7 @@ type alias FrontendModel =
     , groupTransactions :
         List
             { transactionId : TransactionId
+            , spendingId : SpendingId
             , description : String
             , year : Int
             , month : Int
@@ -55,6 +57,7 @@ type Page
 
 type alias BackendModel =
     { years : Dict Int Year
+    , spendings : Array Spending
     , groups : Dict String Group
 
     -- person set -> group -> amount
@@ -62,6 +65,7 @@ type alias BackendModel =
     , totalGroupCredits : Dict String (Dict String (Amount Credit))
     , persons : Dict String Person
     , nextPersonId : Int
+    , nextSpendingId : SpendingId
     , loggedInSessions : Set SessionId
     }
 
@@ -72,9 +76,9 @@ type FrontendMsg
     | NoOpFrontendMsg
     | ShowAddPersonDialog
     | ShowAddGroupDialog
-    | ShowAddSpendingDialog (Maybe TransactionId) -- Nothing for create, Just for edit
-    | ShowConfirmDeleteDialog TransactionId
-    | ConfirmDeleteTransaction TransactionId
+    | ShowAddSpendingDialog (Maybe SpendingReference) -- Nothing for create, Just for edit
+    | ShowConfirmDeleteDialog SpendingId
+    | ConfirmDeleteSpending SpendingId
     | SetToday Date
     | Submit
     | Cancel
@@ -82,14 +86,22 @@ type FrontendMsg
     | AddMember String
     | UpdateMember Int String
     | UpdateShare Int String
-    | ChangeDatePicker DatePicker.ChangeEvent
-    | UpdateTotal String
-    | AddCreditor String
-    | UpdateCreditor Int String
-    | UpdateCredit Int String
-    | AddDebitor String
-    | UpdateDebitor Int String
-    | UpdateDebit Int String
+    | UpdateSpendingDate DatePicker.ChangeEvent
+    | UpdateSpendingTotal String
+    | AddCredit
+    | RemoveCredit Int
+    | ToggleCreditDetails Int
+    | UpdateCreditDate Int DatePicker.ChangeEvent
+    | UpdateCreditSecondaryDescription Int String
+    | UpdateCreditGroup Int String
+    | UpdateCreditAmount Int String
+    | AddDebit
+    | RemoveDebit Int
+    | ToggleDebitDetails Int
+    | UpdateDebitDate Int DatePicker.ChangeEvent
+    | UpdateDebitSecondaryDescription Int String
+    | UpdateDebitGroup Int String
+    | UpdateDebitAmount Int String
     | UpdateGroupName String
     | UpdatePassword String
     | UpdateJson String
@@ -106,25 +118,17 @@ type ToBackend
     | CreateGroup String (Dict String Share)
     | CreateSpending
         { description : String
-        , year : Int
-        , month : Int
-        , day : Int
         , total : Amount Credit
-        , credits : Dict String (Amount Credit)
-        , debits : Dict String (Amount Debit)
+        , transactions : List SpendingTransaction
         }
-    | EditTransaction
-        { transactionId : TransactionId
+    | EditSpending
+        { spendingId : SpendingId
         , description : String
-        , year : Int
-        , month : Int
-        , day : Int
         , total : Amount Credit
-        , credits : Dict String (Amount Credit)
-        , debits : Dict String (Amount Debit)
+        , transactions : List SpendingTransaction
         }
-    | DeleteTransaction TransactionId
-    | RequestTransactionDetails TransactionId
+    | DeleteSpending SpendingId
+    | RequestSpendingDetails SpendingId
     | RequestUserGroups String
     | RequestGroupTransactions String
     | RequestAllTransactions
@@ -133,11 +137,32 @@ type ToBackend
     | ImportJson String
 
 
+type alias SpendingId =
+    Int
+
+
 type alias TransactionId =
     { year : Int
     , month : Int
     , day : Int
     , index : Int
+    }
+
+
+type alias SpendingReference =
+    { spendingId : SpendingId
+    , transactionId : TransactionId
+    }
+
+
+type alias SpendingTransaction =
+    { year : Int
+    , month : Int
+    , day : Int
+    , secondaryDescription : String
+    , group : String
+    , amount : Amount ()
+    , side : TransactionSide
     }
 
 
@@ -171,6 +196,7 @@ type ToFrontend
         , transactions :
             List
                 { transactionId : TransactionId
+                , spendingId : SpendingId
                 , description : String
                 , year : Int
                 , month : Int
@@ -181,16 +207,12 @@ type ToFrontend
         }
     | AuthenticationStatus Bool
     | JsonExport String
-    | TransactionError String
-    | TransactionDetails
-        { transactionId : TransactionId
+    | SpendingError String
+    | SpendingDetails
+        { spendingId : SpendingId
         , description : String
-        , year : Int
-        , month : Int
-        , day : Int
         , total : Amount Credit
-        , credits : Dict String (Amount Credit)
-        , debits : Dict String (Amount Debit)
+        , transactions : List SpendingTransaction
         }
 
 
@@ -198,7 +220,7 @@ type Dialog
     = AddPersonDialog AddPersonDialogModel
     | AddGroupDialog AddGroupDialogModel
     | AddSpendingDialog AddSpendingDialogModel
-    | ConfirmDeleteDialog TransactionId
+    | ConfirmDeleteDialog SpendingId
     | PasswordDialog PasswordDialogModel
 
 
@@ -232,19 +254,27 @@ type NameValidity
 
 
 type alias AddSpendingDialogModel =
-    { transactionId : Maybe TransactionId -- Nothing for create, Just for edit
+    { spendingId : Maybe SpendingId -- Nothing for create, Just for edit
     , description : String
+    , total : String
     , date : Maybe Date
     , dateText : String
     , datePickerModel : DatePicker.Model
-    , total : String
-
-    -- group name, amount, name validity
-    , credits : List ( String, String, NameValidity )
-
-    -- group name, amount, name validity
-    , debits : List ( String, String, NameValidity )
+    , credits : List TransactionLine
+    , debits : List TransactionLine
     , submitted : Bool
+    }
+
+
+type alias TransactionLine =
+    { date : Maybe Date
+    , dateText : String
+    , datePickerModel : DatePicker.Model
+    , secondaryDescription : String
+    , detailsExpanded : Bool
+    , group : String
+    , amount : String
+    , nameValidity : NameValidity
     }
 
 
@@ -267,26 +297,37 @@ type alias Month =
 
 
 type alias Day =
-    { spendings : List Spending
+    { transactions : List Transaction
     , totalGroupCredits : Dict String (Dict String (Amount Credit))
     }
 
 
 type alias Spending =
     { description : String
-
-    -- total amount of the transaction
     , total : Amount Credit
+    , transactionIds : List TransactionId
 
-    -- groups that receive credit (positive amounts)
-    , credits : Dict String (Amount Credit)
-
-    -- groups that are debited (positive amounts, but semantically debits)
-    , debits : Dict String (Amount Debit)
-
-    -- status of the transaction
+    -- status of the spending
     , status : TransactionStatus
     }
+
+
+type alias Transaction =
+    { id : TransactionId
+    , spendingId : SpendingId
+    , secondaryDescription : String
+    , group : String
+    , amount : Amount ()
+    , side : TransactionSide
+    , groupMembersKey : String
+    , groupMembers : Set String
+    , status : TransactionStatus
+    }
+
+
+type TransactionSide
+    = CreditTransaction
+    | DebitTransaction
 
 
 type TransactionStatus


### PR DESCRIPTION
This PR contains frontend-only fixes:\n- Keep per-line .date as Nothing until manually edited; dateText still reflects dialog-level default.\n- On spending date change, update only line.dateText/datePickerModel for default lines (do not set line.date).\n- Increased compact detail date width to 200px.\n\nFiles: src/Frontend.elm, .squad/agents/hicks/history.md\n\nThis is a draft PR for review by Théo and Vasquez.